### PR TITLE
feature/CATC_16-add-board-state-to-a-global-state

### DIFF
--- a/src/services/board/board-service-local.js
+++ b/src/services/board/board-service-local.js
@@ -1,5 +1,7 @@
 import { storageService } from "../async-storage-service";
 import { loadFromStorage, makeId, saveToStorage } from "../util-service";
+import boardDataGenerator from "./board-data-generator";
+import { USER_STORAGE_KEY } from "../user/user-service-local.js";
 
 const BOARDS_STORAGE_KEY = "boardDB";
 _createBoards();
@@ -8,9 +10,12 @@ export const boardService = {
   query,
   getById,
   remove,
+  save,
   updateBoardWithActivity,
+  clearData,
+  reCreateBoards,
 };
-window.cs = boardService;
+window.bs = boardService;
 
 async function query() {
   try {
@@ -44,9 +49,7 @@ async function remove(boardId) {
 
 async function updateBoardWithActivity(
   board,
-  { key, value },
-  listId = null,
-  cardId = null
+  { listId = null, cardId = null, key, value }
 ) {
   try {
     if (!board || !key) throw new Error("Board and key are required");
@@ -67,7 +70,7 @@ async function updateBoardWithActivity(
       cardId
     );
 
-    return _save(updatedBoard);
+    return save(updatedBoard);
   } catch (error) {
     console.error("Cannot update board:", error);
 
@@ -158,7 +161,7 @@ function _createActivity(
   };
 }
 
-async function _save(board) {
+export async function save(board) {
   try {
     if (board._id) {
       return await storageService.put(BOARDS_STORAGE_KEY, { ...board });
@@ -175,284 +178,19 @@ async function _save(board) {
 function _createBoards() {
   let boards = loadFromStorage(BOARDS_STORAGE_KEY);
   if (!boards || !boards.length) {
-    boards = [];
-    boards.push(_createBoard());
-
-    saveToStorage(BOARDS_STORAGE_KEY, boards);
+    const data = boardDataGenerator.generateSampleData();
+    const { sampleBoards, allUsers } = data;
+    saveToStorage(BOARDS_STORAGE_KEY, sampleBoards);
+    saveToStorage(USER_STORAGE_KEY, allUsers);
   }
 }
 
-function _createBoard() {
-  return {
-    id: makeId(),
-    type: "board",
-    name: "Project Alpha",
-    description: "Main development board for Project Alpha",
-    createdAt: "1760391084016",
-    updatedAt: "1760391111653",
-    lists: [
-      {
-        id: makeId(),
-        type: "list",
-        name: "To Do",
-        cards: [
-          {
-            id: makeId(),
-            title: "Set up project repo",
-            description: "Initialize repository and push base structure",
-            labels: [
-              { name: "frontend", color: "blue" },
-              { name: "priority:high", color: "green" },
-            ],
-            assignedTo: ["user-1"],
-            createdAt: "1760391124118",
-            dueDate: "1760391142172",
-          },
-          {
-            id: makeId(),
-            title: "Define API endpoints",
-            description: "Draft a list of REST endpoints for backend",
-            labels: [{ name: "frontend", color: "blue" }],
-            assignedTo: ["user-2"],
-            createdAt: "1760391148666",
-          },
-        ],
-      },
-      {
-        id: makeId(),
-        type: "list",
-        name: "In Progress",
-        cards: [
-          {
-            id: makeId(),
-            title: "Design login page",
-            description: "Create wireframe for login and register screens",
-            labels: [
-              { name: "backend", color: "blue" },
-              { name: "priority:high", color: "red" },
-            ],
-            assignedTo: ["user-3"],
-            createdAt: "1760391156864",
-          },
-        ],
-      },
-      {
-        id: makeId(),
-        type: "list",
-        name: "Done",
-        cards: [],
-      },
-      // New demo lists
-      {
-        id: makeId(),
-        type: "list",
-        name: "Review",
-        cards: [
-          {
-            id: makeId(),
-            title: "Code review login feature",
-            description: "Review pull request #12",
-            labels: [{ name: "backend", color: "yellow" }],
-            assignedTo: ["user-4"],
-            createdAt: "1760391200000",
-          },
-          {
-            id: makeId(),
-            title: "Review API endpoints",
-            description: "Check REST endpoints documentation",
-            labels: [{ name: "frontend", color: "blue" }],
-            assignedTo: ["user-2"],
-            createdAt: "1760391210000",
-          },
-          {
-            id: makeId(),
-            title: "UI/UX review",
-            description: "Check design consistency",
-            labels: [{ name: "design", color: "purple" }],
-            assignedTo: ["user-5"],
-            createdAt: "1760391220000",
-          },
-        ],
-      },
-      {
-        id: makeId(),
-        type: "list",
-        name: "Blocked",
-        cards: [
-          {
-            id: makeId(),
-            title: "Waiting for API approval",
-            description: "Cannot proceed until backend confirms endpoints",
-            labels: [{ name: "backend", color: "red" }],
-            assignedTo: ["user-3"],
-            createdAt: "1760391230000",
-          },
-        ],
-      },
-      {
-        id: makeId(),
-        type: "list",
-        name: "Ideas",
-        cards: [
-          {
-            id: makeId(),
-            title: "New dashboard layout",
-            description: "Sketch initial dashboard ideas",
-            labels: [{ name: "design", color: "purple" }],
-            assignedTo: ["user-5"],
-            createdAt: "1760391240000",
-          },
-          {
-            id: makeId(),
-            title: "Integrate notifications",
-            description: "Consider push notifications for events",
-            labels: [{ name: "frontend", color: "blue" }],
-            assignedTo: ["user-1"],
-            createdAt: "1760391250000",
-          },
-        ],
-      },
-    ],
-    activities: [
-      {
-        id: makeId(),
-        type: "activity",
-        activityType: "card_created",
-        userId: "user-1",
-        cardId: "card-12",
-        message: "User created card 'Set up project repo' in 'To Do'",
-        previousData: null,
-        currentData: {
-          id: "card-12",
-          title: "Set up project repo",
-          listId: "list-1",
-        },
-        timestamp: "1760391167252",
-      },
-      {
-        id: makeId(),
-        type: "activity",
-        activityType: "card_created",
-        userId: "user-2",
-        cardId: "card-13",
-        message: "User created card 'Define API endpoints' in 'To Do'",
-        previousData: null,
-        currentData: {
-          id: "card-13",
-          title: "Define API endpoints",
-          listId: "list-1",
-        },
-        timestamp: "1760391185949",
-      },
-      {
-        id: makeId(),
-        type: "activity",
-        activityType: "card_created",
-        userId: "user-3",
-        cardId: "card-7",
-        message: "User created card 'Design login page' in 'In Progress'",
-        previousData: null,
-        currentData: {
-          id: "card-7",
-          title: "Design login page",
-          listId: "list-4",
-        },
-        timestamp: "1760391195759",
-      },
-      // New activities for "Review" list
-      {
-        id: makeId(),
-        type: "activity",
-        activityType: "card_created",
-        userId: "user-4",
-        cardId: "card-21",
-        message: "User created card 'Code review login feature' in 'Review'",
-        previousData: null,
-        currentData: {
-          id: "card-21",
-          title: "Code review login feature",
-          listId: "list-5",
-        },
-        timestamp: "1760391260000",
-      },
-      {
-        id: makeId(),
-        type: "activity",
-        activityType: "card_created",
-        userId: "user-2",
-        cardId: "card-22",
-        message: "User created card 'Review API endpoints' in 'Review'",
-        previousData: null,
-        currentData: {
-          id: "card-22",
-          title: "Review API endpoints",
-          listId: "list-5",
-        },
-        timestamp: "1760391270000",
-      },
-      {
-        id: makeId(),
-        type: "activity",
-        activityType: "card_created",
-        userId: "user-5",
-        cardId: "card-23",
-        message: "User created card 'UI/UX review' in 'Review'",
-        previousData: null,
-        currentData: {
-          id: "card-23",
-          title: "UI/UX review",
-          listId: "list-5",
-        },
-        timestamp: "1760391280000",
-      },
-      // Activity for "Blocked" list
-      {
-        id: makeId(),
-        type: "activity",
-        activityType: "card_created",
-        userId: "user-3",
-        cardId: "card-31",
-        message: "User created card 'Waiting for API approval' in 'Blocked'",
-        previousData: null,
-        currentData: {
-          id: "card-31",
-          title: "Waiting for API approval",
-          listId: "list-6",
-        },
-        timestamp: "1760391290000",
-      },
-      // Activities for "Ideas" list
-      {
-        id: makeId(),
-        type: "activity",
-        activityType: "card_created",
-        userId: "user-5",
-        cardId: "card-41",
-        message: "User created card 'New dashboard layout' in 'Ideas'",
-        previousData: null,
-        currentData: {
-          id: "card-41",
-          title: "New dashboard layout",
-          listId: "list-7",
-        },
-        timestamp: "1760391300000",
-      },
-      {
-        id: makeId(),
-        type: "activity",
-        activityType: "card_created",
-        userId: "user-1",
-        cardId: "card-42",
-        message: "User created card 'Integrate notifications' in 'Ideas'",
-        previousData: null,
-        currentData: {
-          id: "card-42",
-          title: "Integrate notifications",
-          listId: "list-7",
-        },
-        timestamp: "1760391310000",
-      },
-    ],
-    listOrder: ["list-1", "list-4", "list-3", "list-5", "list-6", "list-7"],
-  };
+function clearData() {
+  saveToStorage(BOARDS_STORAGE_KEY, []);
+  saveToStorage(USER_STORAGE_KEY, []);
+}
+
+function reCreateBoards() {
+  clearData();
+  _createBoards();
 }

--- a/src/store/actions/board-actions.js
+++ b/src/store/actions/board-actions.js
@@ -2,7 +2,7 @@ import {
   SET_BOARDS,
   ADD_BOARD,
   UPDATE_BOARD,
-  REMOVE_BOARD,
+  DELETE_BOARD,
   SET_BOARD,
   SET_LOADING,
   SET_ERROR,
@@ -37,10 +37,7 @@ export async function loadBoard(boardId) {
 
 export async function createBoard(board) {
   try {
-    const newBoard = await boardService.updateBoardWithActivity(board, {
-      key: "created board",
-      value: "",
-    });
+    const newBoard = await boardService.save(board);
     store.dispatch(addBoard(newBoard));
     return newBoard;
   } catch (error) {
@@ -49,9 +46,17 @@ export async function createBoard(board) {
   }
 }
 
-export async function updateBoard(board) {
+export async function updateBoard(
+  board,
+  { listId = null, cardId = null, key, value }
+) {
   try {
-    const updatedBoard = await boardService.updateBoardWithActivity(board);
+    const updatedBoard = await boardService.updateBoardWithActivity(board, {
+      listId,
+      cardId,
+      key,
+      value,
+    });
     store.dispatch(editBoard(updatedBoard));
     return updatedBoard;
   } catch (error) {
@@ -60,10 +65,10 @@ export async function updateBoard(board) {
   }
 }
 
-export async function removeBoard(boardId) {
+export async function deleteBoard(boardId) {
   try {
     await boardService.remove(boardId);
-    store.dispatch(deleteBoard(boardId));
+    store.dispatch(deleteBoardAction(boardId));
   } catch (error) {
     store.dispatch(setError(`Error removing board: ${error.message}`));
     throw error;
@@ -82,8 +87,8 @@ export function editBoard(board) {
   return { type: UPDATE_BOARD, payload: board };
 }
 
-export function deleteBoard(boardId) {
-  return { type: REMOVE_BOARD, payload: boardId };
+export function deleteBoardAction(boardId) {
+  return { type: DELETE_BOARD, payload: boardId };
 }
 
 export function setBoard(board) {

--- a/src/store/actions/board-actions.js
+++ b/src/store/actions/board-actions.js
@@ -1,0 +1,99 @@
+import {
+  SET_BOARDS,
+  ADD_BOARD,
+  UPDATE_BOARD,
+  REMOVE_BOARD,
+  SET_BOARD,
+  SET_LOADING,
+  SET_ERROR,
+} from "../reducers/board-reducer";
+
+import { store } from "../store";
+import { boardService } from "../../services/board/board-service-local";
+
+export async function loadBoards() {
+  try {
+    store.dispatch(setLoading(true));
+    const boards = await boardService.query();
+    store.dispatch(setBoards(boards));
+  } catch (error) {
+    store.dispatch(setError(`Error loading boards: ${error.message}`));
+  } finally {
+    store.dispatch(setLoading(false));
+  }
+}
+
+export async function loadBoard(boardId) {
+  try {
+    store.dispatch(setLoading(true));
+    const board = await boardService.getById(boardId);
+    store.dispatch(setBoard(board));
+  } catch (error) {
+    store.dispatch(setError(`Error loading board: ${error.message}`));
+  } finally {
+    store.dispatch(setLoading(false));
+  }
+}
+
+export async function createBoard(board) {
+  try {
+    const newBoard = await boardService.updateBoardWithActivity(board, {
+      key: "created board",
+      value: "",
+    });
+    store.dispatch(addBoard(newBoard));
+    return newBoard;
+  } catch (error) {
+    store.dispatch(setError(`Error creating board: ${error.message}`));
+    throw error;
+  }
+}
+
+export async function updateBoard(board) {
+  try {
+    const updatedBoard = await boardService.updateBoardWithActivity(board);
+    store.dispatch(editBoard(updatedBoard));
+    return updatedBoard;
+  } catch (error) {
+    store.dispatch(setError(`Error updating board: ${error.message}`));
+    throw error;
+  }
+}
+
+export async function removeBoard(boardId) {
+  try {
+    await boardService.remove(boardId);
+    store.dispatch(deleteBoard(boardId));
+  } catch (error) {
+    store.dispatch(setError(`Error removing board: ${error.message}`));
+    throw error;
+  }
+}
+
+export function setBoards(boards) {
+  return { type: SET_BOARDS, payload: boards };
+}
+
+export function addBoard(board) {
+  return { type: ADD_BOARD, payload: board };
+}
+
+export function editBoard(board) {
+  return { type: UPDATE_BOARD, payload: board };
+}
+
+export function deleteBoard(boardId) {
+  return { type: REMOVE_BOARD, payload: boardId };
+}
+
+export function setBoard(board) {
+  return { type: SET_BOARD, payload: board };
+}
+
+export function setLoading(isLoading) {
+  return { type: SET_LOADING, payload: isLoading };
+}
+
+export function setError(error) {
+  return { type: SET_ERROR, payload: error };
+}

--- a/src/store/reducers/board-reducer.js
+++ b/src/store/reducers/board-reducer.js
@@ -3,8 +3,8 @@ export const SET_BOARD = "SET_BOARD";
 export const REMOVE_BOARD = "REMOVE_BOARD";
 export const ADD_BOARD = "ADD_BOARD";
 export const UPDATE_BOARD = "UPDATE_BOARD";
-export const SET_LOADING = "SET_LOADING";
-export const SET_ERROR = "SET_ERROR";
+export const SET_LOADING = "boards/SET_LOADING";
+export const SET_ERROR = "boards/SET_ERROR";
 
 const initialState = {
   boards: [],

--- a/src/store/reducers/board-reducer.js
+++ b/src/store/reducers/board-reducer.js
@@ -1,0 +1,39 @@
+export const SET_BOARDS = "SET_BOARDS";
+export const SET_BOARD = "SET_BOARD";
+export const REMOVE_BOARD = "REMOVE_BOARD";
+export const ADD_BOARD = "ADD_BOARD";
+export const UPDATE_BOARD = "UPDATE_BOARD";
+export const SET_LOADING = "SET_LOADING";
+export const SET_ERROR = "SET_ERROR";
+
+const initialState = {
+  boards: [],
+  board: null,
+  isLoading: false,
+  error: null,
+};
+
+export function boardReducer(state = initialState, action) {
+  switch (action.type) {
+    case SET_BOARDS:
+      return { ...state, boards: action.payload };
+    case SET_BOARD:
+      return { ...state, board: action.payload };
+    case REMOVE_BOARD:
+      const boards = state.boards.filter(board => board._id !== action.payload);
+      return { ...state, boards };
+    case ADD_BOARD:
+      return { ...state, boards: [...state.boards, action.payload] };
+    case UPDATE_BOARD:
+      const updatedBoards = state.boards.map(board =>
+        board._id === action.payload._id ? action.payload : board
+      );
+      return { ...state, boards: updatedBoards };
+    case SET_LOADING:
+      return { ...state, isLoading: action.payload };
+    case SET_ERROR:
+      return { ...state, error: action.payload };
+    default:
+      return state;
+  }
+}

--- a/src/store/reducers/board-reducer.js
+++ b/src/store/reducers/board-reducer.js
@@ -1,6 +1,6 @@
 export const SET_BOARDS = "SET_BOARDS";
 export const SET_BOARD = "SET_BOARD";
-export const REMOVE_BOARD = "REMOVE_BOARD";
+export const DELETE_BOARD = "DELETE_BOARD";
 export const ADD_BOARD = "ADD_BOARD";
 export const UPDATE_BOARD = "UPDATE_BOARD";
 export const SET_LOADING = "boards/SET_LOADING";
@@ -19,7 +19,7 @@ export function boardReducer(state = initialState, action) {
       return { ...state, boards: action.payload };
     case SET_BOARD:
       return { ...state, board: action.payload };
-    case REMOVE_BOARD:
+    case DELETE_BOARD:
       const boards = state.boards.filter(board => board._id !== action.payload);
       return { ...state, boards };
     case ADD_BOARD:

--- a/src/store/reducers/user-reducer.js
+++ b/src/store/reducers/user-reducer.js
@@ -4,8 +4,8 @@ export const SET_USERS = "SET_USERS";
 export const SET_USER = "SET_USER";
 export const SET_WATCHED_USER = "SET_WATCHED_USER";
 export const DELETE_USER = "DELETE_USER";
-export const SET_LOADING = "SET_LOADING";
-export const SET_ERROR = "SET_ERROR";
+export const SET_LOADING = "users/SET_LOADING";
+export const SET_ERROR = "users/SET_ERROR";
 
 const initialState = {
   users: [],

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,8 +1,9 @@
 import { legacy_createStore as createStore, combineReducers } from "redux";
-
+import { boardReducer } from "./reducers/board-reducer";
 import { userReducer } from "./reducers/user-reducer";
 
 const rootReducer = combineReducers({
+  boards: boardReducer,
   users: userReducer,
 });
 
@@ -10,10 +11,3 @@ const middleware = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
   ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__()
   : undefined;
 export const store = createStore(rootReducer, middleware);
-
-// For debug:
-// store.subscribe(() => {
-//     console.log('**** Store state changed: ****')
-//     console.log('storeState:\n', store.getState())
-//     console.log('*******************************')
-// })


### PR DESCRIPTION
## Description
This branch adds a reducer and actions for managing board state globally across the app.

## Changes
- Add a board reducer that also includes loading and error states.
- Add actions for changing board state.

## Notes
- I used a common pattern than we haven't used in class before but can be found in the starter code, which is action creators - pure functions that return an action object. This decouples components from action structure, and allows for easier refactoring of the action structure when needed (instead of updating object literals in multiple places).
- I also the same key for all actions updated data - `payload`. In my opinion this makes it more intuitive to add additional cases in the reducer, and generally easier to work with actions as you know what structure to anticipate.