### PR TITLE
feat: Added edit card from the card itself #CATC-35

### DIFF
--- a/src/assets/styles/components/Card.css
+++ b/src/assets/styles/components/Card.css
@@ -21,6 +21,9 @@
 }
 
 .floating-card-content {
+  display: inline-block;
+  position: relative;
+  overflow: visible;
   display: flex;
   flex-direction: column;
   border-radius: 6px;
@@ -29,6 +32,26 @@
   color: var(--gray1);
   padding: 0.5rem;
   text-align: left;
+}
+
+.card-save-button {
+  position: absolute;
+  bottom: -2.5rem;
+  left: 0;
+  background: #8fb8f6;
+  color: black;
+  border: 1px solid var(--black);
+  border-radius: 6px;
+  padding: 0.5rem;
+  font-size: 1em;
+  font-weight: 500;
+  letter-spacing: 0.5px;
+  overflow: hidden;
+  transition: 0.2s ease;
+}
+
+.card-save-button:hover {
+  background: #6f9ce6;
 }
 
 .card-edit-button {
@@ -60,6 +83,25 @@
   font-size: 1.15em;
   font-weight: normal;
   padding: 0.25rem 0.5rem 0.5rem 0.3rem;
+  word-break: break-word;
+}
+
+.card-title-input {
+  display: block;
+  word-break: break-all;
+  border: none;
+  outline: none;
+  background: none;
+  color: var(--gray1);
+  font-family: inherit;
+  font-size: 1.15em;
+  font-weight: normal;
+  padding: 0.25rem 0.5rem 0.5rem 0.3rem;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow: hidden;
+  resize: none;
+  field-sizing: content; /* auto-grow/shrink to content check if works cross-browser*/
 }
 
 .card-footer {

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -3,6 +3,7 @@ import {
   NotesRounded,
   RemoveRedEyeOutlined,
   DriveFileRenameOutline,
+  SaveSharp,
 } from "@mui/icons-material";
 
 import CardPopover from "./CardPopover";
@@ -12,6 +13,7 @@ import { useState } from "react";
 
 export function Card({ card, onRemoveCard, onUpdateCard }) {
   const [anchorEl, setAnchorEl] = useState(null);
+  const [title, setTitle] = useState(card.title);
 
   function handleClick(e) {
     setAnchorEl(e.currentTarget);
@@ -19,9 +21,13 @@ export function Card({ card, onRemoveCard, onUpdateCard }) {
 
   function handleClose() {
     setAnchorEl(null);
+    setTitle(card.title);
   }
 
-  function handleSave() {}
+  function handleSave() {
+    card.title = title;
+    handleClose();
+  }
 
   function handleDelete() {
     onRemoveCard(card.id);
@@ -33,47 +39,72 @@ export function Card({ card, onRemoveCard, onUpdateCard }) {
 
   return (
     <section className="card-container">
-      <Box
-        className={`${open ? "floating-card-content" : "card-content"}`}
-        sx={open ? { zIndex: theme => theme.zIndex.modal + 1 } : {}}
-      >
-        {card.labels.length > 0 && (
-          <div className="card-labels">
-            {card.labels.map(label => (
-              <div
-                key={`${card.id}-${label.name}`}
-                className={`card-label ${label.color}`}
-              >
-                {label.name}
-              </div>
-            ))}
-          </div>
-        )}
-        <h3 className={`card-title ${card.labels.length === 0 ? "mr-2" : ""}`}>
-          {card.title}
-        </h3>
-        {open ? (
+      {open ? (
+        <Box
+          className="floating-card-content"
+          sx={{ zIndex: theme => theme.zIndex.modal + 2 }}
+        >
+          {card.labels.length > 0 && (
+            <div className="card-labels">
+              {card.labels.map(label => (
+                <div
+                  key={`${card.id}-${label.name}`}
+                  className={`card-label ${label.color}`}
+                >
+                  {label.name}
+                </div>
+              ))}
+            </div>
+          )}
+          <textarea
+            className="card-title-input"
+            value={title}
+            onChange={e => setTitle(e.target.value)}
+          />
           <div className="card-footer">
             <div className="empty-card-footer" />
           </div>
-        ) : (
+          <button className="icon-button card-edit-button" />
+          <button onClick={handleSave} className="icon-button card-save-button">
+            Save
+          </button>
+        </Box>
+      ) : (
+        <Box className="card-content">
+          {card.labels.length > 0 && (
+            <div className="card-labels">
+              {card.labels.map(label => (
+                <div
+                  key={`${card.id}-${label.name}`}
+                  className={`card-label ${label.color}`}
+                >
+                  {label.name}
+                </div>
+              ))}
+            </div>
+          )}
+
+          <h3
+            className={`card-title ${card.labels.length === 0 ? "mr-2" : ""}`}
+          >
+            {card.title}
+          </h3>
+
           <div className="card-footer">
             <RemoveRedEyeOutlined />
             <ChatRounded />
             <NotesRounded />
           </div>
-        )}
-        <button
-          onClick={handleClick}
-          aria-describedby={id}
-          aria-label="Edit card"
-          className="icon-button card-edit-button"
-        >
-          <DriveFileRenameOutline />
-        </button>
-      </Box>
-
-      {/* We could send the card object to the popover to edit the card which would be more efficient */}
+          <button
+            onClick={handleClick}
+            aria-describedby={id}
+            aria-label="Edit card"
+            className="icon-button card-edit-button"
+          >
+            <DriveFileRenameOutline />
+          </button>
+        </Box>
+      )}
       <CardPopover
         open={open}
         anchorEl={anchorEl}

--- a/src/components/CardPopover.jsx
+++ b/src/components/CardPopover.jsx
@@ -21,6 +21,8 @@ export default function CardPopover({
     >
       <Popover
         disableScrollLock
+        disableEnforceFocus
+        disableAutoFocus
         className="card-popover"
         id={id}
         open={open}


### PR DESCRIPTION
#### Card Title Inline Editing Feature

#### What I Did

- Added the ability to **edit the card title directly from the card** by clicking the **edit button** on the top-right corner of the card.
- While editing the title:
  - Pressing **Save** will save the updated title **locally** (for now).
  - Clicking **anywhere outside** the editing area will **exit the edit mode without saving**, discarding changes.

## Notes

- The editing UI is inline and replaces the static title temporarily.
- The feature currently stores changes **only locally**