### PR TITLE
feature/CATC_27-allow-users-to-add-a-list-to-a-board

### DIFF
--- a/src/assets/styles/components/Board.css
+++ b/src/assets/styles/components/Board.css
@@ -77,29 +77,6 @@
   flex-shrink: 0;
 }
 
-.add-list-button {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.5rem;
-  width: 100%;
-  font-size: 1.2rem;
-  font-weight: bold;
-  color: var(--gray1);
-  background: var(--clr2);
-  border: 1px solid var(--gray1);
-  border-radius: 8px;
-  > svg {
-    width: 16px;
-    height: 16px;
-    color: var(--gray1);
-  }
-}
-
-.add-list-button:hover {
-  background-color: var(--gray3);
-}
-
 .board-header-right {
   display: flex;
   gap: 0.5rem;

--- a/src/assets/styles/main.css
+++ b/src/assets/styles/main.css
@@ -28,3 +28,5 @@
 @import "components/review/ReviewEdit";
 @import "components/review/ReviewList";
 @import "components/review/ReviewPreview";
+
+@import "pages/BoardDetails";

--- a/src/assets/styles/pages/BoardDetails.css
+++ b/src/assets/styles/pages/BoardDetails.css
@@ -1,0 +1,22 @@
+.add-list-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem;
+  width: 100%;
+  font-size: 1.2rem;
+  font-weight: bold;
+  color: var(--gray1);
+  background: var(--clr2);
+  border: 1px solid var(--gray1);
+  border-radius: 8px;
+  > svg {
+    width: 16px;
+    height: 16px;
+    color: var(--gray1);
+  }
+}
+
+.add-list-button:hover {
+  background-color: var(--gray3);
+}

--- a/src/components/AddList.jsx
+++ b/src/components/AddList.jsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+
+import IconButton from "@mui/material/IconButton";
+import Button from "@mui/material/Button";
+import TextField from "@mui/material/TextField";
+import AddIcon from "@mui/icons-material/Add";
+import CloseIcon from "@mui/icons-material/Close";
+
+import { boardService } from "../services/board";
+
+export function AddList({ onSubmit }) {
+  const [showAddList, setShowAddList] = useState(true);
+  const [listName, setListName] = useState("");
+
+  function onSubmitAddList() {
+    if (!listName) return;
+    const newList = boardService.getEmptyList();
+    newList.name = listName;
+    onSubmit(newList);
+    setListName("");
+    setShowAddList(true);
+  }
+
+  return (
+    <>
+      {showAddList && (
+        <Button
+          startIcon={<AddIcon />}
+          className="add-list-button"
+          onClick={() => setShowAddList(false)}
+        >
+          Add another list
+        </Button>
+      )}
+      {!showAddList && (
+        <div className="add-list-container">
+          <div>
+            <TextField
+              id="outlined-basic"
+              variant="outlined"
+              value={listName}
+              placeholder="Enter list name"
+              onChange={e => setListName(e.target.value)}
+            />
+          </div>
+          <Button onClick={onSubmitAddList}>Add List</Button>
+          <IconButton aria-label="close" onClick={() => setShowAddList(true)}>
+            <CloseIcon />
+          </IconButton>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/pages/BoardDetails.jsx
+++ b/src/pages/BoardDetails.jsx
@@ -1,20 +1,16 @@
-import { AddRounded } from "@mui/icons-material";
-import {
-  MoreHoriz,
-  Sort,
-  StarBorderRounded,
-  LockOutlineRounded,
-} from "@mui/icons-material";
+import MoreHoriz from "@mui/icons-material/MoreHoriz";
+import Sort from "@mui/icons-material/Sort";
+import StarBorderRounded from "@mui/icons-material/StarBorderRounded";
+import LockOutlineRounded from "@mui/icons-material/LockOutlineRounded";
 
 import { updateBoard } from "../store/actions/board-actions";
-import { List } from "../components/List";
 import { Footer } from "../components/Footer";
+import { List } from "../components/List";
+import { AddList } from "../components/AddList";
 import { showErrorMsg, showSuccessMsg } from "../services/event-bus-service";
 
 export function BoardDetails({ board }) {
   async function onRemoveList(listId) {}
-
-  async function onAddList() {}
 
   async function onUpdateList(list, { cardId = null, key, value }) {
     try {
@@ -26,6 +22,14 @@ export function BoardDetails({ board }) {
       showErrorMsg(`Unable to update the list: ${list.name}`);
     }
   }
+  function onSubmitAddList(newList) {
+    updateBoard(board, {
+      key: "lists",
+      value: [...board.lists, newList],
+    });
+  }
+
+  if (!board) return <div>Loading board...</div>;
 
   return (
     <section className="board-container">
@@ -59,7 +63,7 @@ export function BoardDetails({ board }) {
             </li>
           ))}
           <li>
-            <AddListButton />
+            <AddList onSubmit={onSubmitAddList} />
           </li>
         </ul>
         <nav className="board-footer">
@@ -67,13 +71,5 @@ export function BoardDetails({ board }) {
         </nav>
       </div>
     </section>
-  );
-}
-
-function AddListButton() {
-  return (
-    <button className="add-list-button">
-      <AddRounded /> Add a List
-    </button>
   );
 }

--- a/src/pages/BoardDetails.jsx
+++ b/src/pages/BoardDetails.jsx
@@ -1,3 +1,4 @@
+import { useSelector } from "react-redux";
 import MoreHoriz from "@mui/icons-material/MoreHoriz";
 import Sort from "@mui/icons-material/Sort";
 import StarBorderRounded from "@mui/icons-material/StarBorderRounded";
@@ -9,7 +10,9 @@ import { List } from "../components/List";
 import { AddList } from "../components/AddList";
 import { showErrorMsg, showSuccessMsg } from "../services/event-bus-service";
 
-export function BoardDetails({ board }) {
+export function BoardDetails() {
+  const board = useSelector(state => state.boards.board);
+
   async function onRemoveList(listId) {}
 
   async function onUpdateList(list, { cardId = null, key, value }) {

--- a/src/pages/BoardDetails.jsx
+++ b/src/pages/BoardDetails.jsx
@@ -1,17 +1,24 @@
+import { useEffect } from "react";
 import { useSelector } from "react-redux";
+import { useParams } from "react-router";
 import MoreHoriz from "@mui/icons-material/MoreHoriz";
 import Sort from "@mui/icons-material/Sort";
 import StarBorderRounded from "@mui/icons-material/StarBorderRounded";
 import LockOutlineRounded from "@mui/icons-material/LockOutlineRounded";
 
-import { updateBoard } from "../store/actions/board-actions";
+import { loadBoard, updateBoard } from "../store/actions/board-actions";
 import { Footer } from "../components/Footer";
 import { List } from "../components/List";
 import { AddList } from "../components/AddList";
 import { showErrorMsg, showSuccessMsg } from "../services/event-bus-service";
 
 export function BoardDetails() {
+  const params = useParams();
   const board = useSelector(state => state.boards.board);
+
+  useEffect(() => {
+    loadBoard(params.boardId);
+  }, [params.boardId]);
 
   async function onRemoveList(listId) {}
 

--- a/src/pages/BoardIndex.jsx
+++ b/src/pages/BoardIndex.jsx
@@ -1,12 +1,23 @@
 import { useEffect } from "react";
+import { useSelector } from "react-redux";
+import { useNavigate } from "react-router-dom";
 import { BoardDetails } from "./BoardDetails";
 import { boardService } from "../services/board";
-import { loadBoard } from "../store/actions/board-actions";
+import { loadBoard, loadBoards } from "../store/actions/board-actions";
 
 export function BoardIndex() {
+  const boards = useSelector(state => state.boards.boards);
+  const navigate = useNavigate();
+
   useEffect(() => {
-    fetchBoard();
+    loadBoards();
   }, []);
+
+  useEffect(() => {
+    if (boards.length === 0) return;
+
+    navigate(`/board/${boards[0]._id}`);
+  }, [boards]);
 
   async function fetchBoard() {
     const boards = await boardService.query();

--- a/src/pages/BoardIndex.jsx
+++ b/src/pages/BoardIndex.jsx
@@ -1,12 +1,9 @@
-import { useState, useEffect } from "react";
-import { useSelector } from "react-redux";
+import { useEffect } from "react";
 import { BoardDetails } from "./BoardDetails";
 import { boardService } from "../services/board";
 import { loadBoard } from "../store/actions/board-actions";
 
 export function BoardIndex() {
-  const board = useSelector(state => state.boards.board);
-
   useEffect(() => {
     fetchBoard();
   }, []);
@@ -16,11 +13,9 @@ export function BoardIndex() {
     await loadBoard(boards[0]._id);
   }
 
-  if (!board) return <div>Loading board...</div>;
-
   return (
     <section className="board-index">
-      <BoardDetails board={board} />
+      <BoardDetails />
     </section>
   );
 }

--- a/src/pages/BoardIndex.jsx
+++ b/src/pages/BoardIndex.jsx
@@ -1,9 +1,11 @@
 import { useState, useEffect } from "react";
+import { useSelector } from "react-redux";
 import { BoardDetails } from "./BoardDetails";
 import { boardService } from "../services/board";
+import { loadBoard } from "../store/actions/board-actions";
 
 export function BoardIndex() {
-  const [board, setBoard] = useState(null);
+  const board = useSelector(state => state.boards.board);
 
   useEffect(() => {
     fetchBoard();
@@ -11,7 +13,7 @@ export function BoardIndex() {
 
   async function fetchBoard() {
     const boards = await boardService.query();
-    setBoard(boards[0]);
+    await loadBoard(boards[0]._id);
   }
 
   if (!board) return <div>Loading board...</div>;

--- a/src/services/board/board-service-local.js
+++ b/src/services/board/board-service-local.js
@@ -14,6 +14,7 @@ export const boardService = {
   updateBoardWithActivity,
   clearData,
   reCreateBoards,
+  getEmptyList,
 };
 window.bs = boardService;
 
@@ -76,6 +77,14 @@ async function updateBoardWithActivity(
 
     throw error;
   }
+}
+
+export function getEmptyList() {
+  return {
+    id: crypto.randomUUID(),
+    name: "",
+    cards: [],
+  };
 }
 
 function _applyBoardUpdate(

--- a/src/store/reducers/board-reducer.js
+++ b/src/store/reducers/board-reducer.js
@@ -28,7 +28,16 @@ export function boardReducer(state = initialState, action) {
       const updatedBoards = state.boards.map(board =>
         board._id === action.payload._id ? action.payload : board
       );
-      return { ...state, boards: updatedBoards };
+      const updatedCurrentBoard =
+        state.board && state.board._id === action.payload._id
+          ? action.payload
+          : state.board;
+
+      return {
+        ...state,
+        boards: updatedBoards,
+        board: updatedCurrentBoard,
+      };
     case SET_LOADING:
       return { ...state, isLoading: action.payload };
     case SET_ERROR:

--- a/src/store/reducers/board-reducer.js
+++ b/src/store/reducers/board-reducer.js
@@ -25,19 +25,7 @@ export function boardReducer(state = initialState, action) {
     case ADD_BOARD:
       return { ...state, boards: [...state.boards, action.payload] };
     case UPDATE_BOARD:
-      const updatedBoards = state.boards.map(board =>
-        board._id === action.payload._id ? action.payload : board
-      );
-      const updatedCurrentBoard =
-        state.board && state.board._id === action.payload._id
-          ? action.payload
-          : state.board;
-
-      return {
-        ...state,
-        boards: updatedBoards,
-        board: updatedCurrentBoard,
-      };
+      return { ...state, board: action.payload };
     case SET_LOADING:
       return { ...state, isLoading: action.payload };
     case SET_ERROR:


### PR DESCRIPTION
## Description
This PR add functionality to allow users to create a new list directly from the board.

## Changes
- `UPDATE_BOARD` action also updates the board property in the store so that components that subscribe to updates of the board could re-render.
- `BoardDetails` not gets board state directly from the store instead of props. The page structure is wrong and needs to be fixed in a separate issue (`BoardIndex` renders `BoardDetails`).
- Add a simple AddForm component that uses local state to keep track of the list name, and on submit, updates the board lists array.

## Code review changes:
- Load boards using store actions in the `BoardIndex` compnent, and immediately navigate to the first boards details page.
-  Use `usParams` and load the board in `BoardDetails` from the store using the id from params.
- In the board-reducer, avoid updating the boards array in the `UPDATE_BOARD` actions, and instead, update the board object.

## Demo
[Screencast from 10-19-2025 06:56:59 PM.webm](https://github.com/user-attachments/assets/e1a88145-2ec9-4b4c-bdc0-c7920a9e48b8)


