### PR TITLE
feat: Added save changes of edited card #CATC-37

### DIFF
--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -27,6 +27,7 @@ export function Card({ card, onRemoveCard, onUpdateCard }) {
   function handleSave() {
     card.title = title;
     handleClose();
+    onUpdateCard({ ...card, title });
   }
 
   function handleDelete() {

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -20,7 +20,8 @@ export function List({ list, onRemoveList, onUpdateList }) {
   }
 
   async function onUpdateCard(card) {
-    await onUpdateList(card);
+    setCards(prev => [...prev, card]);
+    await onUpdateList({ ...list, cards });
   }
 
   const handleMoreClick = event => {

--- a/src/pages/BoardDetails.jsx
+++ b/src/pages/BoardDetails.jsx
@@ -12,9 +12,6 @@ import {
 export function BoardDetails({ board }) {
   async function onRemoveList(listId) {}
 
-<<<<<<< Updated upstream
-  async function onAddList() {}
-=======
   async function onUpdateList(list) {
     updateBoard(board, {
       listId: list.id,
@@ -22,7 +19,6 @@ export function BoardDetails({ board }) {
       value: [...list.cards],
     });
   }
->>>>>>> Stashed changes
 
   async function onUpdateList(list) {}
 

--- a/src/pages/BoardDetails.jsx
+++ b/src/pages/BoardDetails.jsx
@@ -12,7 +12,17 @@ import {
 export function BoardDetails({ board }) {
   async function onRemoveList(listId) {}
 
+<<<<<<< Updated upstream
   async function onAddList() {}
+=======
+  async function onUpdateList(list) {
+    updateBoard(board, {
+      listId: list.id,
+      key: "cards",
+      value: [...list.cards],
+    });
+  }
+>>>>>>> Stashed changes
 
   async function onUpdateList(list) {}
 


### PR DESCRIPTION
### In-Card Editing Save

**Description:**  
Added the functionality to save edits made directly within a card.

**Notes:**  
- These changes depend on the previous visual editing branch #13
- Also depends on @sabellius's branch for adding a new list #14
- This branch should be merged **after** the above branches are merged.
