### PR TITLE
feature/CATC_39-create-filter-state-management-and-utility-functions 

### DIFF
--- a/src/hooks/useCardFilters.js
+++ b/src/hooks/useCardFilters.js
@@ -1,0 +1,35 @@
+import { useSelector, useDispatch } from "react-redux";
+import { useCallback } from "react";
+import { setFilters, clearAllFilters } from "../store/actions/board-actions";
+
+export const useCardFilters = () => {
+  const dispatch = useDispatch();
+  const filters = useSelector(state => state.boards.filterBy);
+
+  const updateFilter = useCallback(
+    (filterType, value) => {
+      dispatch(setFilters({ [filterType]: value }));
+    },
+    [dispatch]
+  );
+
+  const removeFilter = useCallback(
+    (type, value) => {
+      if (type === "title") {
+        dispatch(setFilters({ title: "" }));
+      }
+    },
+    [dispatch]
+  );
+
+  const handleClearAllFilters = useCallback(() => {
+    dispatch(clearAllFilters());
+  }, [dispatch]);
+
+  return {
+    filters,
+    updateFilter,
+    removeFilter,
+    clearAllFilters: handleClearAllFilters,
+  };
+};

--- a/src/services/filter-service.js
+++ b/src/services/filter-service.js
@@ -23,3 +23,11 @@ export function getFilteredBoard(board, filterBy) {
     })),
   };
 }
+
+export function getDefaultFilter() {
+  return {
+    labels: [],
+    title: "",
+    includeNoLabels: false,
+  };
+}

--- a/src/services/filter-service.js
+++ b/src/services/filter-service.js
@@ -1,0 +1,25 @@
+export function filterCards(cards, filterBy) {
+  if (!cards || !filterBy) return cards;
+
+  const { title = "" } = filterBy;
+
+  if (!title) {
+    return cards;
+  }
+
+  return cards.filter(card => {
+    return card.title?.toLowerCase().includes(title.toLowerCase());
+  });
+}
+
+export function getFilteredBoard(board, filterBy) {
+  if (!board?.lists) return board;
+
+  return {
+    ...board,
+    lists: board.lists.map(list => ({
+      ...list,
+      cards: filterCards(list.cards, filterBy),
+    })),
+  };
+}

--- a/src/store/actions/board-actions.js
+++ b/src/store/actions/board-actions.js
@@ -6,6 +6,8 @@ import {
   SET_BOARD,
   SET_LOADING,
   SET_ERROR,
+  SET_FILTERS,
+  CLEAR_ALL_FILTERS,
 } from "../reducers/board-reducer";
 
 import { store } from "../store";
@@ -101,4 +103,12 @@ export function setLoading(isLoading) {
 
 export function setError(error) {
   return { type: SET_ERROR, payload: error };
+}
+
+export function setFilters(filterBy) {
+  return { type: SET_FILTERS, payload: filterBy };
+}
+
+export function clearAllFilters() {
+  return { type: CLEAR_ALL_FILTERS };
 }

--- a/src/store/reducers/board-reducer.js
+++ b/src/store/reducers/board-reducer.js
@@ -5,12 +5,19 @@ export const ADD_BOARD = "ADD_BOARD";
 export const UPDATE_BOARD = "UPDATE_BOARD";
 export const SET_LOADING = "boards/SET_LOADING";
 export const SET_ERROR = "boards/SET_ERROR";
+export const SET_FILTERS = "boards/SET_FILTERS";
+export const CLEAR_ALL_FILTERS = "boards/CLEAR_ALL_FILTERS";
 
 const initialState = {
   boards: [],
   board: null,
   isLoading: false,
   error: null,
+  filterBy: {
+    labels: [],
+    title: "",
+    includeNoLabels: false,
+  },
 };
 
 export function boardReducer(state = initialState, action) {
@@ -30,6 +37,16 @@ export function boardReducer(state = initialState, action) {
       return { ...state, isLoading: action.payload };
     case SET_ERROR:
       return { ...state, error: action.payload };
+    case SET_FILTERS:
+      return {
+        ...state,
+        filterBy: { ...state.filterBy, ...action.payload },
+      };
+    case CLEAR_ALL_FILTERS:
+      return {
+        ...state,
+        filterBy: getDefaultFilter(),
+      };
     default:
       return state;
   }

--- a/src/store/reducers/board-reducer.js
+++ b/src/store/reducers/board-reducer.js
@@ -1,3 +1,5 @@
+import { getDefaultFilter } from "../../services/filter-service";
+
 export const SET_BOARDS = "SET_BOARDS";
 export const SET_BOARD = "SET_BOARD";
 export const DELETE_BOARD = "DELETE_BOARD";
@@ -13,11 +15,7 @@ const initialState = {
   board: null,
   isLoading: false,
   error: null,
-  filterBy: {
-    labels: [],
-    title: "",
-    includeNoLabels: false,
-  },
+  filterBy: getDefaultFilter(),
 };
 
 export function boardReducer(state = initialState, action) {


### PR DESCRIPTION
## Description

Added Redux state management for card filtering with utility functions to support future filter implementations. Currently implements title-based filtering as a foundation for expanding filter capabilities.

## Changes

- __Add `filterBy` state to Redux__: New state object in board reducer to manage filter criteria.
- __Add Redux actions__: `SET_FILTERS` and `CLEAR_ALL_FILTERS` actions for filter state management.
- __Creat filter service__: Utility functions for applying filters to cards and boards.
- __Implement title filtering__: Basic title search functionality as starting point for filter system.

## Notes
- Only title filtering is currently implemented to establish the foundation.
- Filter state structure is designed to support additional filter types (labels, dates, etc.) in future iterations.
- Ready for UI component development and extension with more filter options.
- Filter service provides clean abstraction for board/card filtering logic.

