### PR TITLE
feature/CATC_38-implement-members-filtering

### DIFF
--- a/src/assets/styles/components/FilterMenu.css
+++ b/src/assets/styles/components/FilterMenu.css
@@ -1,0 +1,14 @@
+.filter-member-autocomplete .MuiAutocomplete-popupIndicator {
+  transform: none;
+  transition: none;
+}
+
+.filter-member-fullname {
+  font-size: 0.85em;
+}
+
+.filter-member-username {
+  color: #888;
+  font-size: 0.6em;
+  margin-left: 4px;
+}

--- a/src/assets/styles/main.css
+++ b/src/assets/styles/main.css
@@ -27,6 +27,7 @@
 @import "components/Board";
 @import "components/List";
 @import "components/Card";
+@import "components/FilterMenu";
 
 @import "components/review/ReviewEdit";
 @import "components/review/ReviewList";

--- a/src/components/FilterMenu.jsx
+++ b/src/components/FilterMenu.jsx
@@ -22,8 +22,13 @@ export function FilterMenu() {
   const [isOpen, setIsOpen] = useState(false);
   const [localTitle, setLocalTitle] = useState("");
   const anchorRef = useRef(null);
-  const { filters, updateFilterDebounced, updateFilter, clearAllFilters } =
-    useCardFilters();
+  const {
+    filters,
+    updateFilterDebounced,
+    updateFilter,
+    clearAllFilters,
+    hasActiveFilters,
+  } = useCardFilters();
   const memberOptions = useMemo(
     () => getMembersFilterOptions(members),
     [members]
@@ -97,12 +102,6 @@ export function FilterMenu() {
       </li>
     );
   }
-
-  const hasActiveFilters = () => {
-    return (
-      filters.title?.trim() || filters?.members?.length || !!filters.noMembers
-    );
-  };
 
   function handleMembersAutocompleteChange(_, selected) {
     let newMembers = selected.map(m => m.id);

--- a/src/components/FilterMenu.jsx
+++ b/src/components/FilterMenu.jsx
@@ -1,4 +1,5 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useMemo } from "react";
+import { useSelector } from "react-redux";
 import Popover from "@mui/material/Popover";
 import IconButton from "@mui/material/IconButton";
 import Box from "@mui/material/Box";
@@ -7,39 +8,109 @@ import TextField from "@mui/material/TextField";
 import Button from "@mui/material/Button";
 import FilterList from "@mui/icons-material/FilterList";
 import { useCardFilters } from "../hooks/useCardFilters";
+import Checkbox from "@mui/material/Checkbox";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import FormGroup from "@mui/material/FormGroup";
+import Autocomplete from "@mui/material/Autocomplete";
+import {
+  CURRENT_USER_ID_PLACEHOLDER,
+  getMembersFilterOptions,
+} from "../services/filter-service";
 
 export function FilterMenu() {
+  const members = useSelector(state => state.boards.board.members);
   const [isOpen, setIsOpen] = useState(false);
   const [localTitle, setLocalTitle] = useState("");
   const anchorRef = useRef(null);
-  const { filters, updateFilterDebounced, clearAllFilters } = useCardFilters();
+  const { filters, updateFilterDebounced, updateFilter, clearAllFilters } =
+    useCardFilters();
+  const memberOptions = useMemo(
+    () => getMembersFilterOptions(members),
+    [members]
+  );
 
   useEffect(() => {
     setLocalTitle(filters.title || "");
   }, [filters.title]);
 
-  const handleClearFilters = () => {
+  function handleClearFilters() {
     setLocalTitle("");
     clearAllFilters();
-  };
+  }
 
-  const handleOpen = () => {
+  function handleOpen() {
     setIsOpen(true);
-  };
+  }
 
-  const handleClose = () => {
+  function handleClose() {
     setIsOpen(false);
-  };
+  }
 
-  const handleTitleChange = event => {
+  function handleTitleChange(event) {
     const value = event.target.value;
     setLocalTitle(value);
     updateFilterDebounced("title", value);
-  };
+  }
+
+  function handleMembersChange(event, checked) {
+    const checkboxName = event.target.name;
+    let newMembers;
+    if (checkboxName === "assignedToMe") {
+      newMembers = filters.members ? [...filters.members] : [];
+      if (checked) {
+        newMembers = [...newMembers, CURRENT_USER_ID_PLACEHOLDER];
+      } else {
+        newMembers = newMembers.filter(
+          id => id !== CURRENT_USER_ID_PLACEHOLDER
+        );
+      }
+    } else if (checkboxName === "selectAll") {
+      if (checked) {
+        newMembers = members
+          .filter(m => m._id !== CURRENT_USER_ID_PLACEHOLDER)
+          .map(m => m._id);
+        if (filters.members?.includes(CURRENT_USER_ID_PLACEHOLDER)) {
+          newMembers = [CURRENT_USER_ID_PLACEHOLDER, ...newMembers];
+        }
+      } else {
+        newMembers = [];
+      }
+    }
+    updateFilter("members", newMembers);
+  }
+
+  function isSomeMembersSelected() {
+    const filtered = members.filter(m => m._id !== CURRENT_USER_ID_PLACEHOLDER);
+    const selectedCount = filtered.filter(m =>
+      filters.members?.includes(m._id)
+    ).length;
+    return selectedCount > 0 && selectedCount < filtered.length;
+  }
+
+  function renderMemberOption(props, option, { selected }) {
+    const { key, ...rest } = props;
+    return (
+      <li key={key} {...rest}>
+        <Checkbox checked={selected} sx={{ mr: 1 }} />
+        <span className="filter-member-fullname">{option.fullname}</span>
+        <span className="filter-member-username">@{option.username}</span>
+      </li>
+    );
+  }
 
   const hasActiveFilters = () => {
-    return filters.title && filters.title.trim() !== "";
+    return (
+      filters.title?.trim() || filters?.members?.length || !!filters.noMembers
+    );
   };
+
+  function handleMembersAutocompleteChange(_, selected) {
+    let newMembers = selected.map(m => m.id);
+    if (filters.members?.includes(CURRENT_USER_ID_PLACEHOLDER)) {
+      newMembers = [CURRENT_USER_ID_PLACEHOLDER, ...newMembers];
+    }
+    updateFilter("members", newMembers);
+  }
 
   return (
     <>
@@ -69,7 +140,6 @@ export function FilterMenu() {
           <Typography variant="h6" sx={{ mb: 2, textAlign: "center" }}>
             Filter
           </Typography>
-
           <Box sx={{ mb: 2 }}>
             <Typography variant="subtitle2" sx={{ mb: 1 }}>
               Title
@@ -82,7 +152,71 @@ export function FilterMenu() {
               onChange={handleTitleChange}
             />
           </Box>
-
+          <FormGroup row sx={{ mb: 1, alignItems: "center" }}>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  name="noMembers"
+                  checked={!!filters.noMembers}
+                  onChange={(_, checked) => updateFilter("noMembers", checked)}
+                />
+              }
+              label="No members"
+              sx={{ mr: 2 }}
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  name="assignedToMe"
+                  checked={filters.members?.includes(
+                    CURRENT_USER_ID_PLACEHOLDER
+                  )}
+                  onChange={handleMembersChange}
+                />
+              }
+              label="Assigned to me"
+              sx={{ mr: 2 }}
+            />
+          </FormGroup>
+          <Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  name="selectAll"
+                  checked={
+                    memberOptions.length > 0 &&
+                    memberOptions
+                      .filter(m => m.id !== CURRENT_USER_ID_PLACEHOLDER)
+                      .every(m => filters.members?.includes(m.id))
+                  }
+                  indeterminate={isSomeMembersSelected()}
+                  onChange={handleMembersChange}
+                  sx={{ mr: 1 }}
+                />
+              }
+              label=""
+              sx={{ mr: 2 }}
+            />
+            <Box className="filter-member-autocomplete" sx={{ flex: 1 }}>
+              <Autocomplete
+                multiple
+                disableCloseOnSelect
+                disableClearable
+                options={memberOptions}
+                getOptionLabel={option => option.label}
+                value={memberOptions.filter(
+                  m =>
+                    filters.members?.includes(m.id) &&
+                    m.id !== CURRENT_USER_ID_PLACEHOLDER
+                )}
+                onChange={handleMembersAutocompleteChange}
+                renderOption={renderMemberOption}
+                renderValue={() => null}
+                renderInput={params => <TextField {...params} size="small" />}
+                sx={{ mb: 0, width: "100%" }}
+              />
+            </Box>
+          </Box>
           <Box sx={{ display: "flex", gap: 1 }}>
             <Button
               variant="outlined"

--- a/src/hooks/useCardFilters.js
+++ b/src/hooks/useCardFilters.js
@@ -35,11 +35,18 @@ export const useCardFilters = () => {
     dispatch(clearAllFilters());
   }, [dispatch]);
 
+  function hasActiveFilters() {
+    return (
+      filters.title?.trim() || filters?.members?.length || !!filters.noMembers
+    );
+  }
+
   return {
     filters,
     updateFilter,
     updateFilterDebounced,
     removeFilter,
     clearAllFilters: handleClearAllFilters,
+    hasActiveFilters,
   };
 };

--- a/src/pages/BoardDetails.jsx
+++ b/src/pages/BoardDetails.jsx
@@ -21,8 +21,8 @@ export function BoardDetails() {
   const { filters } = useCardFilters();
 
   useEffect(() => {
-    loadBoard(params.boardId);
-  }, [params.boardId]);
+    loadBoard(params.boardId, filters);
+  }, [params.boardId, filters]);
 
   async function onRemoveList(listId) {}
 
@@ -42,11 +42,6 @@ export function BoardDetails() {
       value: [...board.lists, newList],
     });
   }
-
-  const filteredBoard = useMemo(() => {
-    if (!board) return null;
-    return getFilteredBoard(board, filters);
-  }, [board, filters]);
 
   if (!board) return <div>Loading board...</div>;
 
@@ -72,7 +67,7 @@ export function BoardDetails() {
       </header>
       <div className="board-canvas">
         <ul className="lists-list">
-          {filteredBoard.lists.map(list => (
+          {board.lists.map(list => (
             <li key={list.id}>
               <List
                 key={list.id}

--- a/src/services/board/board-service-local.js
+++ b/src/services/board/board-service-local.js
@@ -2,6 +2,7 @@ import { storageService } from "../async-storage-service";
 import { loadFromStorage, makeId, saveToStorage } from "../util-service";
 import boardDataGenerator from "./board-data-generator";
 import { USER_STORAGE_KEY } from "../user/user-service-local.js";
+import { getFilteredBoard } from "../filter-service";
 
 const BOARDS_STORAGE_KEY = "boardDB";
 _createBoards();
@@ -28,9 +29,10 @@ async function query() {
   }
 }
 
-function getById(boardId) {
+async function getById(boardId, filterBy = {}) {
   try {
-    return storageService.get(BOARDS_STORAGE_KEY, boardId);
+    const board = await storageService.get(BOARDS_STORAGE_KEY, boardId);
+    return getFilteredBoard(board, filterBy);
   } catch (error) {
     console.log("Cannot get board:", error);
 

--- a/src/services/filter-service.js
+++ b/src/services/filter-service.js
@@ -1,14 +1,34 @@
+export const CURRENT_USER_ID_PLACEHOLDER = "currentUserId";
+
 export function filterCards(cards, filterBy) {
   if (!cards || !filterBy) return cards;
 
-  const { title = "" } = filterBy;
-
-  if (!title) {
-    return cards;
-  }
+  const { title = "", noMembers = false, members = [] } = filterBy;
 
   return cards.filter(card => {
-    return card.title?.toLowerCase().includes(title.toLowerCase());
+    if (title && !card.title?.toLowerCase().includes(title.toLowerCase())) {
+      return false;
+    }
+
+    const hasNoMembers = !card.assignedTo || card.assignedTo.length === 0;
+    const matchesMembers =
+      members && members.length > 0
+        ? card.assignedTo && members.some(m => card.assignedTo.includes(m))
+        : false;
+
+    if (noMembers && members && members.length > 0) {
+      return hasNoMembers || matchesMembers;
+    }
+
+    if (noMembers) {
+      return hasNoMembers;
+    }
+
+    if (members && members.length > 0) {
+      return matchesMembers;
+    }
+
+    return true;
   });
 }
 
@@ -29,5 +49,17 @@ export function getDefaultFilter() {
     labels: [],
     title: "",
     includeNoLabels: false,
+    noMembers: false,
+    members: [],
   };
+}
+
+export function getMembersFilterOptions(members) {
+  if (!members) return [];
+  return members.map(member => ({
+    id: member._id,
+    label: member.fullname,
+    fullname: member.fullname,
+    username: member.username,
+  }));
 }

--- a/src/store/actions/board-actions.js
+++ b/src/store/actions/board-actions.js
@@ -25,10 +25,10 @@ export async function loadBoards() {
   }
 }
 
-export async function loadBoard(boardId) {
+export async function loadBoard(boardId, filterBy = {}) {
   try {
     store.dispatch(setLoading(true));
-    const board = await boardService.getById(boardId);
+    const board = await boardService.getById(boardId, filterBy);
     store.dispatch(setBoard(board));
   } catch (error) {
     store.dispatch(setError(`Error loading board: ${error.message}`));


### PR DESCRIPTION
## 🎯 Description
This PR introduces members filtering to the board and refactors how board filtering is handled for improved clarity and maintainability.

## 🔧 Changes
- Added the ability to filter cards by assigned members, making it easier to focus on relevant tasks.
- Refactored the board filtering logic: filtering is now performed when loading the board, rather than inside the `BoardDetails` component.

## Notes
- I've added a functionality for the "Assigned to me" filter which currently uses a placeholder for the current users' id and doesn't really work right now, but will require a small change to work once we will introduce a current user state with authentication in the future.

## 🖥️ Demo

<details>
  <summary>Click To Expand</summary>

  <p align="center">
    
[Screencast from 10-24-2025 07:57:14 PM.webm](https://github.com/user-attachments/assets/2cb758af-ade3-4a3e-85e7-461463737897)

  </p>

</details>



