### PR TITLE
feature/CATC_51-persist-card-filtering-options-in-url-params

### DIFF
--- a/src/hooks/useCardFilters.js
+++ b/src/hooks/useCardFilters.js
@@ -3,7 +3,7 @@ import { useCallback, useMemo } from "react";
 import { setFilters, clearAllFilters } from "../store/actions/board-actions";
 import { debounce } from "../services/util-service";
 
-export const useCardFilters = () => {
+export function useCardFilters() {
   const dispatch = useDispatch();
   const filters = useSelector(state => state.boards.filterBy);
 
@@ -57,4 +57,4 @@ export const useCardFilters = () => {
     clearAllFilters: handleClearAllFilters,
     hasActiveFilters,
   };
-};
+}

--- a/src/hooks/useCardFilters.js
+++ b/src/hooks/useCardFilters.js
@@ -14,6 +14,13 @@ export const useCardFilters = () => {
     [dispatch]
   );
 
+  const updateFilters = useCallback(
+    filterObj => {
+      dispatch(setFilters(filterObj));
+    },
+    [dispatch]
+  );
+
   const updateFilterDebounced = useMemo(
     () =>
       debounce((filterType, value) => {
@@ -44,6 +51,7 @@ export const useCardFilters = () => {
   return {
     filters,
     updateFilter,
+    updateFilters,
     updateFilterDebounced,
     removeFilter,
     clearAllFilters: handleClearAllFilters,

--- a/src/pages/BoardDetails.jsx
+++ b/src/pages/BoardDetails.jsx
@@ -1,6 +1,7 @@
-import { useEffect, useMemo } from "react";
+import { useEffect } from "react";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router";
+import { useSearchParams } from "react-router-dom";
 import MoreHoriz from "@mui/icons-material/MoreHoriz";
 import Sort from "@mui/icons-material/Sort";
 import StarBorderRounded from "@mui/icons-material/StarBorderRounded";
@@ -12,13 +13,22 @@ import { List } from "../components/List";
 import { AddList } from "../components/AddList";
 import { FilterMenu } from "../components/FilterMenu";
 import { showErrorMsg, showSuccessMsg } from "../services/event-bus-service";
-import { getFilteredBoard } from "../services/filter-service";
+import {
+  parseFiltersFromSearchParams,
+  serializeFiltersToSearchParams,
+} from "../services/filter-service";
 import { useCardFilters } from "../hooks/useCardFilters";
 
 export function BoardDetails() {
   const params = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const board = useSelector(state => state.boards.board);
-  const { filters } = useCardFilters();
+  const { filters, updateFilters } = useCardFilters();
+
+  useEffect(() => {
+    const filterBy = parseFiltersFromSearchParams(searchParams);
+    updateFilters(filterBy);
+  }, []);
 
   useEffect(() => {
     loadBoard(params.boardId, filters);

--- a/src/pages/BoardDetails.jsx
+++ b/src/pages/BoardDetails.jsx
@@ -34,6 +34,11 @@ export function BoardDetails() {
     loadBoard(params.boardId, filters);
   }, [params.boardId, filters]);
 
+  useEffect(() => {
+    const filterBy = serializeFiltersToSearchParams(filters);
+    setSearchParams(filterBy);
+  }, [filters, setSearchParams]);
+
   async function onRemoveList(listId) {}
 
   async function onUpdateList(list, { cardId = null, key, value }) {

--- a/src/services/filter-service.js
+++ b/src/services/filter-service.js
@@ -63,3 +63,43 @@ export function getMembersFilterOptions(members) {
     username: member.username,
   }));
 }
+
+export function parseFiltersFromSearchParams(searchParams) {
+  const filterBy = getDefaultFilter();
+
+  if (searchParams.has("title")) {
+    filterBy.title = searchParams.get("title");
+  }
+
+  if (searchParams.has("noMembers")) {
+    filterBy.noMembers = searchParams.get("noMembers") === "1";
+  }
+
+  if (searchParams.has("members")) {
+    const membersParam = searchParams.get("members");
+    filterBy.members = membersParam
+      .split(",")
+      .map(id => id.trim())
+      .filter(id => id);
+  }
+
+  return filterBy;
+}
+
+export function serializeFiltersToSearchParams(filterBy) {
+  const searchParams = new URLSearchParams();
+
+  if (filterBy.title) {
+    searchParams.set("title", filterBy.title);
+  }
+
+  if (filterBy.noMembers) {
+    searchParams.set("noMembers", "1");
+  }
+
+  if (filterBy.members && filterBy.members.length > 0) {
+    searchParams.set("members", filterBy.members.join(","));
+  }
+
+  return searchParams;
+}

--- a/src/services/filter-service.js
+++ b/src/services/filter-service.js
@@ -66,21 +66,19 @@ export function getMembersFilterOptions(members) {
 
 export function parseFiltersFromSearchParams(searchParams) {
   const filterBy = getDefaultFilter();
+  for (const [key, value] of searchParams.entries()) {
+    if (!(key in filterBy)) continue;
 
-  if (searchParams.has("title")) {
-    filterBy.title = searchParams.get("title");
-  }
-
-  if (searchParams.has("noMembers")) {
-    filterBy.noMembers = searchParams.get("noMembers") === "1";
-  }
-
-  if (searchParams.has("members")) {
-    const membersParam = searchParams.get("members");
-    filterBy.members = membersParam
-      .split(",")
-      .map(id => id.trim())
-      .filter(id => id);
+    if (typeof filterBy[key] === "boolean") {
+      filterBy[key] = value === "1";
+    } else if (Array.isArray(filterBy[key])) {
+      filterBy[key] = value
+        .split(",")
+        .map(v => v.trim())
+        .filter(v => v);
+    } else {
+      filterBy[key] = value;
+    }
   }
 
   return filterBy;
@@ -88,17 +86,14 @@ export function parseFiltersFromSearchParams(searchParams) {
 
 export function serializeFiltersToSearchParams(filterBy) {
   const searchParams = new URLSearchParams();
-
-  if (filterBy.title) {
-    searchParams.set("title", filterBy.title);
-  }
-
-  if (filterBy.noMembers) {
-    searchParams.set("noMembers", "1");
-  }
-
-  if (filterBy.members && filterBy.members.length > 0) {
-    searchParams.set("members", filterBy.members.join(","));
+  for (const [key, value] of Object.entries(filterBy)) {
+    if (Array.isArray(value) && value.length > 0) {
+      searchParams.set(key, value.join(","));
+    } else if (typeof value === "boolean" && value) {
+      searchParams.set(key, "1");
+    } else if (typeof value === "string" && value) {
+      searchParams.set(key, value);
+    }
   }
 
   return searchParams;


### PR DESCRIPTION
## 🎯 Description

This PR implements persistent board filter state via URL parameters.

## 🔧 Changes

- 🆕 **Filter state in URL:** Board filter options (title, members, noMembers) are now synced to the URL using `useSearchParams`.
- 🔄 **Dynamic filter parsing:** Filters are parsed from URL params dynamically using the default filter object, supporting future extensibility.
- 🧹 **Reducer and hook improvements:** Refactored reducer and hooks to support setting the entire filter object and to simplify filter state management.

## 📝 Notes

- The reducer remains pure; all URL param logic is handled in components/hooks.
- If no filter params are present in the URL, the default filter is used.
- Members parsed from the URL are trimmed and filtered to ensure valid IDs.

## 🖥️ Demo

<details>
  <summary>Watch Demo Video</summary>

[Screencast from 10-25-2025 09:28:28 AM.webm](https://github.com/user-attachments/assets/58419f83-c142-4707-8392-029a7e22e42c)

</details>
