### PR TITLE
feature/CATC_24-add-list-popover-menu

### DIFF
--- a/src/assets/styles/components/ListActionsMenu.css
+++ b/src/assets/styles/components/ListActionsMenu.css
@@ -1,0 +1,3 @@
+.list-actions-menu .MuiMenuItem-root:hover {
+  background-color: #ceced912;
+}

--- a/src/assets/styles/components/Popover.css
+++ b/src/assets/styles/components/Popover.css
@@ -1,0 +1,33 @@
+.MuiPaper-root.popover-paper {
+  width: 304px;
+  margin-top: 8px;
+  background-color: #2b2c2f;
+  color: #bfc1c4;
+  box-shadow: 0px 8px 12px #091e4226, 0px 0px 1px #091e424f;
+  border-radius: 0.5rem;
+}
+
+.popover-header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  padding: 0.5rem 1.5rem 0.5rem 1rem;
+  border-bottom: 1px solid #444;
+  min-width: 200px;
+}
+
+.popover-header-title {
+  flex: 1;
+  text-align: center;
+  font-weight: 600;
+  font-size: 1rem;
+  letter-spacing: 0.02em;
+}
+
+.popover-header-close {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+}

--- a/src/assets/styles/main.css
+++ b/src/assets/styles/main.css
@@ -15,6 +15,7 @@
 @import "components/Header";
 @import "components/Footer";
 @import "components/UserMessage";
+@import "components/Popover";
 
 @import "components/car/CarIndex";
 @import "components/car/CarList";

--- a/src/assets/styles/main.css
+++ b/src/assets/styles/main.css
@@ -27,6 +27,7 @@
 
 @import "components/Board";
 @import "components/List";
+@import "components/ListActionsMenu";
 @import "components/Card";
 @import "components/FilterMenu";
 

--- a/src/assets/styles/setup/var.css
+++ b/src/assets/styles/setup/var.css
@@ -69,4 +69,13 @@
   --button-soft-blue-bg: rgb(102, 157, 241);
   --button-very-soft-blue-bg: rgb(143, 184, 246);
   --button-black-text: rgb(21, 21, 23);
+
+  --icon-btn-bg-default: transparent;
+  --icon-btn-bg-hover: #e3e4f21f;
+  --icon-btn-bg-active: #bfc1c4;
+  --icon-btn-bg-active-hover: #cecfd2;
+  --icon-btn-color-default: #a9abaf;
+  --icon-btn-color-hover: #bfc1c4;
+  --icon-btn-color-active: #1f1f21;
+  --icon-btn-color-active-hover: #1f1f21;
 }

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -195,18 +195,14 @@ export function List({ list, boardLabels, onRemoveList, onUpdateList }) {
           vertical: "bottom",
           horizontal: "left",
         }}
-        transformOrigin={{
-          vertical: "top",
-          horizontal: "left",
-        }}
         slotProps={{
           paper: {
             sx: {
-              backgroundColor: "black",
-              color: "white",
-              boxShadow: "none",
-              borderRadius: "5px",
-              border: "1px solid white",
+              mt: 1,
+              backgroundColor: "#2B2C2F",
+              color: "#BFC1C4",
+              boxShadow: "0px 8px 12px #091e4226, 0px 0px 1px #091e424f",
+              borderRadius: "0.5rem",
             },
           },
         }}

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -9,7 +9,9 @@ import MenuItem from "@mui/material/MenuItem";
 import { Card } from "./Card";
 import { boardService } from "../services/board";
 import { CardModal } from "./CardModal";
-import { SquareIconButton } from "./SquareIconButton";
+import { SquareIconButton } from "./ui/buttons/SquareIconButton";
+import Close from "@mui/icons-material/Close";
+import { ListActionsMenu } from "./ListActionsMenu";
 
 export function List({ list, boardLabels, onRemoveList, onUpdateList }) {
   const [cards, setCards] = useState(list.cards);
@@ -187,31 +189,13 @@ export function List({ list, boardLabels, onRemoveList, onUpdateList }) {
         )}
       </div>
 
-      <Popover
-        open={open}
+      <ListActionsMenu
         anchorEl={anchorEl}
+        isOpen={open}
         onClose={handleClose}
-        anchorOrigin={{
-          vertical: "bottom",
-          horizontal: "left",
-        }}
-        slotProps={{
-          paper: {
-            sx: {
-              mt: 1,
-              backgroundColor: "#2B2C2F",
-              color: "#BFC1C4",
-              boxShadow: "0px 8px 12px #091e4226, 0px 0px 1px #091e424f",
-              borderRadius: "0.5rem",
-            },
-          },
-        }}
-      >
-        <MenuList>
-          <MenuItem onClick={handleEditList}>Edit List</MenuItem>
-          <MenuItem onClick={handleDeleteList}>Delete List</MenuItem>
-        </MenuList>
-      </Popover>
+        onEditList={handleEditList}
+        onDeleteList={handleDeleteList}
+      />
 
       {/* Card Modal will be moved out of here */}
       <CardModal

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -9,6 +9,7 @@ import MenuItem from "@mui/material/MenuItem";
 import { Card } from "./Card";
 import { boardService } from "../services/board";
 import { CardModal } from "./CardModal";
+import { SquareIconButton } from "./SquareIconButton";
 
 export function List({ list, boardLabels, onRemoveList, onUpdateList }) {
   const [cards, setCards] = useState(list.cards);
@@ -113,9 +114,11 @@ export function List({ list, boardLabels, onRemoveList, onUpdateList }) {
     <section className="list-container">
       <div className="list-header">
         <h2>{list.name}</h2>
-        <button className="icon-button" onClick={handleMoreClick}>
-          <MoreHoriz />
-        </button>
+        <SquareIconButton
+          icon={<MoreHoriz />}
+          onClick={handleMoreClick}
+          selected={open}
+        />
       </div>
       <div className="list-content-container" ref={listContentRef}>
         <ul className="cards-list">

--- a/src/components/ListActionsMenu.jsx
+++ b/src/components/ListActionsMenu.jsx
@@ -1,0 +1,43 @@
+import MenuList from "@mui/material/MenuList";
+import MenuItem from "@mui/material/MenuItem";
+import ListItemText from "@mui/material/ListItemText";
+import { Popover } from "./Popover";
+import "../assets/styles/components/ListActionsMenu.css";
+
+function listActionsMenuItems() {
+  return [
+    { label: "Add Card", action: () => {} },
+    { label: "Copy List", action: () => {} },
+    { label: "Move List", action: () => {} },
+    { label: "Move All cards in this list", action: () => {} },
+    { label: "Sort list...", action: () => {} },
+    { label: "Watch", action: () => {} },
+    { label: "Archive this list", action: () => {} },
+    { label: "Archive all cards in this list", action: () => {} },
+  ];
+}
+
+export function ListActionsMenu({ anchorEl, isOpen, onClose }) {
+  return (
+    <Popover
+      className="list-actions-menu-popover"
+      anchorEl={anchorEl}
+      open={isOpen}
+      onClose={onClose}
+      title="List actions"
+      anchorOrigin={{
+        vertical: "bottom",
+        horizontal: "left",
+      }}
+      paperProps={{ sx: { mt: 1 } }}
+    >
+      <MenuList className="list-actions-menu" dense>
+        {listActionsMenuItems().map(({ label, action }) => (
+          <MenuItem key={label} onClick={action}>
+            <ListItemText>{label}</ListItemText>
+          </MenuItem>
+        ))}
+      </MenuList>
+    </Popover>
+  );
+}

--- a/src/components/Popover.jsx
+++ b/src/components/Popover.jsx
@@ -1,0 +1,45 @@
+import PopoverMUI from "@mui/material/Popover";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import { SquareIconButton } from "./ui/buttons/SquareIconButton";
+import Close from "@mui/icons-material/Close";
+
+export function Popover({
+  anchorEl,
+  isOpen,
+  onClose,
+  title,
+  children,
+  showClose = true,
+  paperProps = {},
+  ...popoverProps
+}) {
+  return (
+    <PopoverMUI
+      open={isOpen}
+      anchorEl={anchorEl}
+      onClose={onClose}
+      slotProps={{
+        paper: {
+          className: "popover-paper",
+          ...paperProps,
+        },
+      }}
+      {...popoverProps}
+    >
+      <Box className="popover-header">
+        <Typography className="popover-header-title">{title}</Typography>
+        {showClose && (
+          <Box className="popover-header-close">
+            <SquareIconButton
+              icon={<Close />}
+              aria-label="Close"
+              onClick={onClose}
+            />
+          </Box>
+        )}
+      </Box>
+      {children}
+    </PopoverMUI>
+  );
+}

--- a/src/components/ui/buttons/SquareIconButton.jsx
+++ b/src/components/ui/buttons/SquareIconButton.jsx
@@ -1,0 +1,38 @@
+import IconButton from "@mui/material/IconButton";
+
+export function SquareIconButton({
+  icon,
+  onClick,
+  selected = false,
+  sx = {},
+  ...props
+}) {
+  return (
+    <IconButton
+      onClick={onClick}
+      disableRipple
+      size="small"
+      sx={{
+        color: selected
+          ? "var(--icon-btn-color-active)"
+          : "var(--icon-btn-color-default)",
+        backgroundColor: selected
+          ? "var(--icon-btn-bg-active)"
+          : "var(--icon-btn-bg-default)",
+        borderRadius: 1,
+        "&:hover": {
+          backgroundColor: selected
+            ? "var(--icon-btn-bg-active-hover)"
+            : "var(--icon-btn-bg-hover)",
+          color: selected
+            ? "var(--icon-btn-color-active-hover)"
+            : "var(--icon-btn-color-hover)",
+        },
+        ...sx,
+      }}
+      {...props}
+    >
+      {icon}
+    </IconButton>
+  );
+}


### PR DESCRIPTION
## 🎯 Description
Adds custom MUI button and popover components, plus the initial UI for the list actions popover menu.

## 🔧 Changes
- 🆕 Custom MUI button for app-wide use
- 🆕 Custom MUI popover for menu popups
- 🆕 Basic UI for list actions popover menu


## 📝 Notes
- List actions menu is UI only; logic to be added later.
- Custom components are intended for reuse.

## 🖥️ Demo

<details>
  <summary>Click To Expand</summary>

<img width="1917" height="965" alt="2025-10-25_19-04" src="https://github.com/user-attachments/assets/f1a641a6-1805-4c8a-a614-269ebcc5a0d5" />

</details>
