### PR TITLE
feature: Add Label Menu [CATC_59-add-label-menu]

### DIFF
--- a/src/assets/styles/components/Popover.css
+++ b/src/assets/styles/components/Popover.css
@@ -12,7 +12,7 @@
   align-items: center;
   justify-content: center;
   position: relative;
-  padding: 0.5rem 1.5rem 0.5rem 1rem;
+  padding: 0.5rem 2.5rem;
   border-bottom: 1px solid #444;
   min-width: 200px;
 }
@@ -23,6 +23,13 @@
   font-weight: 600;
   font-size: 1rem;
   letter-spacing: 0.02em;
+}
+
+.popover-header-back {
+  position: absolute;
+  left: 8px;
+  top: 50%;
+  transform: translateY(-50%);
 }
 
 .popover-header-close {

--- a/src/assets/styles/components/label/CardLabel.css
+++ b/src/assets/styles/components/label/CardLabel.css
@@ -11,16 +11,16 @@
   overflow: hidden;
 }
 
-.card-label.blue {
-  background-color: var(--label-blue-bg);
-  border: 1px solid var(--label-blue-border);
-  color: var(--label-blue-text);
-}
-
 .card-label.green {
   background-color: var(--label-green-bg);
   border: 1px solid var(--label-green-border);
   color: var(--label-green-text);
+}
+
+.card-label.yellow {
+  background-color: var(--label-yellow-bg);
+  border: 1px solid var(--label-yellow-border);
+  color: var(--label-yellow-text);
 }
 
 .card-label.orange {
@@ -41,10 +41,28 @@
   color: var(--label-purple-text);
 }
 
-.card-label.yellow {
-  background-color: var(--label-yellow-bg);
-  border: 1px solid var(--label-yellow-border);
-  color: var(--label-yellow-text);
+.card-label.blue {
+  background-color: var(--label-blue-bg);
+  border: 1px solid var(--label-blue-border);
+  color: var(--label-blue-text);
+}
+
+.card-label.sky {
+  background-color: var(--label-sky-bg);
+  border: 1px solid var(--label-sky-border);
+  color: var(--label-sky-text);
+}
+
+.card-label.lime {
+  background-color: var(--label-lime-bg);
+  border: 1px solid var(--label-lime-border);
+  color: var(--label-lime-text);
+}
+
+.card-label.pink {
+  background-color: var(--label-pink-bg);
+  border: 1px solid var(--label-pink-border);
+  color: var(--label-pink-text);
 }
 
 .card-label.gray {

--- a/src/assets/styles/components/label/LabelEditor.css
+++ b/src/assets/styles/components/label/LabelEditor.css
@@ -49,7 +49,8 @@
   display: grid;
   grid-template-columns: repeat(5, 1fr);
   gap: 8px;
-  margin-block: 10px;
+  margin-block-start: 10px;
+  margin-block-end: 20px;
 
   .label-color-option {
     width: 100%;
@@ -68,24 +69,6 @@
       border-color: #579dff;
       box-shadow: 0 0 0 2px rgba(87, 157, 255, 0.3);
     }
-  }
-}
-
-.remove-color-btn {
-  width: 100%;
-  padding: 8px;
-  background-color: transparent;
-  border: none;
-  border-radius: 4px;
-  color: #b6c2cf;
-  font-size: 14px;
-  cursor: pointer;
-  text-align: center;
-  margin-bottom: 12px;
-  transition: background-color 0.2s;
-
-  &:hover {
-    background-color: #2c333a;
   }
 }
 
@@ -195,34 +178,3 @@
   border: 1px solid var(--label-gray-border);
   color: var(--label-gray-text);
 }
-
-/* .green {
-  background-color: #4bce97;
-}
-.yellow {
-  background-color: #f5cd47;
-}
-.orange {
-  background-color: #fea362;
-}
-.red {
-  background-color: #f87168;
-}
-.purple {
-  background-color: #9f8fef;
-}
-.blue {
-  background-color: #579dff;
-}
-.sky {
-  background-color: #6cc3e0;
-}
-.lime {
-  background-color: #94c748;
-}
-.pink {
-  background-color: #e774bb;
-}
-.black {
-  background-color: #8590a2;
-} */

--- a/src/assets/styles/components/label/LabelEditor.css
+++ b/src/assets/styles/components/label/LabelEditor.css
@@ -1,0 +1,228 @@
+.label-editor-content {
+  padding: 12px;
+}
+
+.label-preview {
+  height: 38px;
+  padding: 8px 12px;
+  border: 2px solid transparent;
+  border-radius: 4px;
+  margin-bottom: 12px;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.label-editor-field {
+  margin-bottom: 12px;
+
+  .label-editor-label {
+    display: block;
+    font-size: 13px;
+    font-weight: 600;
+    color: #b6c2cf;
+    margin-block: 7px;
+  }
+
+  .label-editor-input {
+    width: 100%;
+    padding: 8px 12px;
+    background-color: #22272b;
+    border: 2px solid #3f4a54;
+    border-radius: 4px;
+    color: #b6c2cf;
+    font-size: 14px;
+    box-sizing: border-box;
+
+    &:focus {
+      outline: none;
+      border-color: #579dff;
+      background-color: #1d2125;
+    }
+
+    &::placeholder {
+      color: #8c9bab;
+    }
+  }
+}
+
+.color-grid {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 8px;
+  margin-block: 10px;
+
+  .label-color-option {
+    width: 100%;
+    height: 32px;
+    border: 2px solid transparent;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.2s;
+
+    &:hover {
+      opacity: 0.8;
+      transform: scale(1.05);
+    }
+
+    &.selected {
+      border-color: #579dff;
+      box-shadow: 0 0 0 2px rgba(87, 157, 255, 0.3);
+    }
+  }
+}
+
+.remove-color-btn {
+  width: 100%;
+  padding: 8px;
+  background-color: transparent;
+  border: none;
+  border-radius: 4px;
+  color: #b6c2cf;
+  font-size: 14px;
+  cursor: pointer;
+  text-align: center;
+  margin-bottom: 12px;
+  transition: background-color 0.2s;
+
+  &:hover {
+    background-color: #2c333a;
+  }
+}
+
+.label-editor-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+
+  .save-btn {
+    flex: 1;
+    padding: 8px 16px;
+    background-color: #579dff;
+    border: none;
+    border-radius: 4px;
+    color: #1d2125;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s;
+
+    &:hover {
+      background-color: #4c8fef;
+    }
+
+    &:active {
+      background-color: #3f7cdb;
+    }
+  }
+
+  .delete-btn {
+    padding: 8px 16px;
+    background-color: #ca3521;
+    border: none;
+    border-radius: 4px;
+    color: #ffffff;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s;
+
+    &:hover {
+      background-color: #ae2a19;
+    }
+
+    &:active {
+      background-color: #932116;
+    }
+  }
+}
+
+.label-color-option.green {
+  background-color: var(--label-green-bg);
+  border: 1px solid var(--label-green-border);
+  color: var(--label-green-text);
+}
+
+.label-color-option.yellow {
+  background-color: var(--label-yellow-bg);
+  border: 1px solid var(--label-yellow-border);
+  color: var(--label-yellow-text);
+}
+
+.label-color-option.orange {
+  background-color: var(--label-orange-bg);
+  border: 1px solid var(--label-orange-border);
+  color: var(--label-orange-text);
+}
+
+.label-color-option.red {
+  background-color: var(--label-red-bg);
+  border: 1px solid var(--label-red-border);
+  color: var(--label-red-text);
+}
+
+.label-color-option.purple {
+  background-color: var(--label-purple-bg);
+  border: 1px solid var(--label-purple-border);
+  color: var(--label-purple-text);
+}
+
+.label-color-option.blue {
+  background-color: var(--label-blue-bg);
+  border: 1px solid var(--label-blue-border);
+  color: var(--label-blue-text);
+}
+
+.label-color-option.sky {
+  background-color: var(--label-sky-bg);
+  border: 1px solid var(--label-sky-border);
+  color: var(--label-sky-text);
+}
+
+.label-color-option.lime {
+  background-color: var(--label-lime-bg);
+  border: 1px solid var(--label-lime-border);
+  color: var(--label-lime-text);
+}
+
+.label-color-option.pink {
+  background-color: var(--label-pink-bg);
+  border: 1px solid var(--label-pink-border);
+  color: var(--label-pink-text);
+}
+
+.label-color-option.gray {
+  background-color: var(--label-gray-bg);
+  border: 1px solid var(--label-gray-border);
+  color: var(--label-gray-text);
+}
+
+/* .green {
+  background-color: #4bce97;
+}
+.yellow {
+  background-color: #f5cd47;
+}
+.orange {
+  background-color: #fea362;
+}
+.red {
+  background-color: #f87168;
+}
+.purple {
+  background-color: #9f8fef;
+}
+.blue {
+  background-color: #579dff;
+}
+.sky {
+  background-color: #6cc3e0;
+}
+.lime {
+  background-color: #94c748;
+}
+.pink {
+  background-color: #e774bb;
+}
+.black {
+  background-color: #8590a2;
+} */

--- a/src/assets/styles/components/label/LabelMenu.css
+++ b/src/assets/styles/components/label/LabelMenu.css
@@ -1,32 +1,19 @@
-.popover-header-title {
-  margin: 0;
-  font-size: 14px;
-  font-weight: 600;
-  color: #b6c2cf;
-}
-
-.popover-header {
-  padding: 12px 16px;
-  border-bottom: 1px solid #3f4a54;
-  text-align: center;
-  position: relative;
-}
-
 .label-menu-content {
   padding: 12px;
 
-  h3 {
-    margin: 0;
-    font-size: 14px;
+  .label-menu-label {
+    display: block;
+    font-size: 13px;
     font-weight: 600;
     color: #b6c2cf;
+    margin-block: 7px;
   }
 }
 
 .label-search {
   width: 100%;
   padding: 8px 12px;
-  margin-bottom: 12px;
+  margin-bottom: 7px;
   background-color: #22272b;
   border: 2px solid #3f4a54;
   border-radius: 4px;

--- a/src/assets/styles/components/label/LabelMenu.css
+++ b/src/assets/styles/components/label/LabelMenu.css
@@ -42,6 +42,13 @@
   }
 }
 
+.no-labels-found {
+  padding: 12px;
+  text-align: center;
+  color: #8c9bab;
+  font-size: 14px;
+}
+
 .create-label-btn {
   width: 100%;
   padding: 8px;

--- a/src/assets/styles/components/label/LabelMenu.css
+++ b/src/assets/styles/components/label/LabelMenu.css
@@ -1,0 +1,72 @@
+.popover-header-title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: #b6c2cf;
+}
+
+.popover-header {
+  padding: 12px 16px;
+  border-bottom: 1px solid #3f4a54;
+  text-align: center;
+  position: relative;
+}
+
+.label-menu-content {
+  padding: 12px;
+
+  h3 {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 600;
+    color: #b6c2cf;
+  }
+}
+
+.label-search {
+  width: 100%;
+  padding: 8px 12px;
+  margin-bottom: 12px;
+  background-color: #22272b;
+  border: 2px solid #3f4a54;
+  border-radius: 4px;
+  color: #b6c2cf;
+  font-size: 14px;
+  box-sizing: border-box;
+
+  &:focus {
+    outline: none;
+    border-color: #579dff;
+    background-color: #1d2125;
+  }
+
+  &::placeholder {
+    color: #8c9bab;
+  }
+}
+
+.labels-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 8px 0;
+
+  li {
+    margin-bottom: 4px;
+  }
+}
+
+.create-label-btn {
+  width: 100%;
+  padding: 8px;
+  background-color: #22272b;
+  border: none;
+  border-radius: 4px;
+  color: #b6c2cf;
+  font-size: 14px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+
+  &:hover {
+    background-color: #2c333a;
+  }
+}

--- a/src/assets/styles/components/label/LabelMenuItem.css
+++ b/src/assets/styles/components/label/LabelMenuItem.css
@@ -1,0 +1,61 @@
+.label-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px;
+  border-radius: 4px;
+}
+
+.label-checkbox {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.label-color-box {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  min-height: 32px;
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: opacity 0.2s;
+
+  &:hover {
+    opacity: 0.9;
+  }
+}
+
+.label-title {
+  color: white;
+  font-size: 14px;
+  font-weight: 600;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+}
+
+.label-edit-btn {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  border-radius: 4px;
+  color: #b6c2cf;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background-color 0.2s;
+
+  &:hover {
+    background-color: #3f4a54;
+    color: #ffffff;
+  }
+
+  svg {
+    width: 16px;
+    height: 16px;
+  }
+}

--- a/src/assets/styles/components/label/ModalLabel.css
+++ b/src/assets/styles/components/label/ModalLabel.css
@@ -48,16 +48,16 @@
   }
 }
 
-.modal-label.blue {
-  background-color: var(--label-blue-bg);
-  border: 1px solid var(--label-blue-border);
-  color: var(--label-blue-text);
-}
-
 .modal-label.green {
   background-color: var(--label-green-bg);
   border: 1px solid var(--label-green-border);
   color: var(--label-green-text);
+}
+
+.modal-label.yellow {
+  background-color: var(--label-yellow-bg);
+  border: 1px solid var(--label-yellow-border);
+  color: var(--label-yellow-text);
 }
 
 .modal-label.orange {
@@ -78,10 +78,28 @@
   color: var(--label-purple-text);
 }
 
-.modal-label.yellow {
-  background-color: var(--label-yellow-bg);
-  border: 1px solid var(--label-yellow-border);
-  color: var(--label-yellow-text);
+.modal-label.blue {
+  background-color: var(--label-blue-bg);
+  border: 1px solid var(--label-blue-border);
+  color: var(--label-blue-text);
+}
+
+.modal-label.sky {
+  background-color: var(--label-sky-bg);
+  border: 1px solid var(--label-sky-border);
+  color: var(--label-sky-text);
+}
+
+.modal-label.lime {
+  background-color: var(--label-lime-bg);
+  border: 1px solid var(--label-lime-border);
+  color: var(--label-lime-text);
+}
+
+.modal-label.pink {
+  background-color: var(--label-pink-bg);
+  border: 1px solid var(--label-pink-border);
+  color: var(--label-pink-text);
 }
 
 .modal-label.gray {

--- a/src/assets/styles/main.css
+++ b/src/assets/styles/main.css
@@ -26,6 +26,7 @@
 @import "components/label/CardLabel";
 @import "components/label/LabelMenu";
 @import "components/label/LabelMenuItem";
+@import "components/label/LabelEditor";
 
 @import "components/Board";
 @import "components/List";

--- a/src/assets/styles/main.css
+++ b/src/assets/styles/main.css
@@ -23,6 +23,8 @@
 
 @import "components/label/ModalLabel";
 @import "components/label/CardLabel";
+@import "components/label/LabelMenu";
+@import "components/label/LabelMenuItem";
 
 @import "components/Board";
 @import "components/List";

--- a/src/assets/styles/setup/var.css
+++ b/src/assets/styles/setup/var.css
@@ -37,29 +37,41 @@
   --error: rgb(216, 59, 59);
 
   /* Label Colors */
-  --label-red-bg: rgb(86, 1, 8);
-  --label-red-border: rgb(146, 1, 14);
-  --label-red-text: rgb(255, 220, 223);
-
   --label-green-bg: rgb(15, 92, 46);
   --label-green-border: rgb(25, 120, 60);
   --label-green-text: rgb(220, 255, 223);
+
+  --label-yellow-bg: rgb(120, 100, 0);
+  --label-yellow-border: rgb(160, 140, 0);
+  --label-yellow-text: rgb(255, 255, 220);
 
   --label-orange-bg: rgb(120, 60, 0);
   --label-orange-border: rgb(160, 80, 0);
   --label-orange-text: rgb(255, 240, 220);
 
-  --label-blue-bg: rgb(0, 60, 120);
-  --label-blue-border: rgb(0, 80, 160);
-  --label-blue-text: rgb(220, 240, 255);
+  --label-red-bg: rgb(86, 1, 8);
+  --label-red-border: rgb(146, 1, 14);
+  --label-red-text: rgb(255, 220, 223);
 
   --label-purple-bg: rgb(60, 0, 120);
   --label-purple-border: rgb(80, 0, 160);
   --label-purple-text: rgb(240, 220, 255);
 
-  --label-yellow-bg: rgb(120, 100, 0);
-  --label-yellow-border: rgb(160, 140, 0);
-  --label-yellow-text: rgb(255, 255, 220);
+  --label-blue-bg: rgb(0, 60, 120);
+  --label-blue-border: rgb(0, 80, 160);
+  --label-blue-text: rgb(220, 240, 255);
+
+  --label-sky-bg: rgb(0, 90, 120);
+  --label-sky-border: rgb(0, 120, 160);
+  --label-sky-text: rgb(220, 245, 255);
+
+  --label-lime-bg: rgb(60, 100, 20);
+  --label-lime-border: rgb(80, 140, 30);
+  --label-lime-text: rgb(240, 255, 220);
+
+  --label-pink-bg: rgb(120, 20, 80);
+  --label-pink-border: rgb(160, 30, 110);
+  --label-pink-text: rgb(255, 220, 245);
 
   --label-gray-bg: rgb(60, 60, 60);
   --label-gray-border: rgb(100, 100, 100);

--- a/src/components/CardModal.jsx
+++ b/src/components/CardModal.jsx
@@ -130,7 +130,6 @@ export function CardModal({
         </footer>
 
         <LabelMenu
-          key={anchorEl ? "open" : "closed"}
           boardId={boardId}
           listId={listId}
           card={card}

--- a/src/components/CardModal.jsx
+++ b/src/components/CardModal.jsx
@@ -13,6 +13,9 @@ export function CardModal({
   boardLabels = [],
   onClose,
   isOpen,
+  onSaveLabel,
+  onRemoveLabel,
+  onUpdateCard,
 }) {
   const [openSection, setOpenSection] = useState(false);
   const [anchorEl, setAnchorEl] = useState(null);
@@ -28,6 +31,24 @@ export function CardModal({
 
   function handleCommentSection() {
     setOpenSection(!openSection);
+  }
+
+  function handleToggleCardLabel(labelId) {
+    const currentLabelIds = card.labels || [];
+    let updatedLabelIds;
+
+    if (currentLabelIds.includes(labelId)) {
+      updatedLabelIds = currentLabelIds.filter(id => id !== labelId);
+    } else {
+      updatedLabelIds = [...currentLabelIds, labelId];
+    }
+
+    const updatedCard = {
+      ...card,
+      labels: updatedLabelIds,
+    };
+
+    onUpdateCard(updatedCard);
   }
 
   if (!card) return null;
@@ -110,9 +131,13 @@ export function CardModal({
 
         <LabelMenu
           boardLabels={boardLabels}
+          cardLabels={cardLabels}
           anchorEl={anchorEl}
           isLabelMenuOpen={isLabelMenuOpen}
           onCloseLabelMenu={onCloseLabelMenu}
+          onSaveLabel={onSaveLabel}
+          onRemoveLabel={onRemoveLabel}
+          onToggleCardLabel={handleToggleCardLabel}
         />
       </Box>
     </Modal>

--- a/src/components/CardModal.jsx
+++ b/src/components/CardModal.jsx
@@ -7,7 +7,9 @@ import AddIcon from "@mui/icons-material/Add";
 import { LabelMenu } from "./LabelMenu";
 
 export function CardModal({
-  list,
+  boardId,
+  listId,
+  listName,
   card,
   cardLabels = [],
   onEditCard,
@@ -43,7 +45,7 @@ export function CardModal({
     <Modal open={isOpen} onClose={onClose}>
       <Box className={`card-modal-box ${openSection ? "open" : "closed"}`}>
         <div className="card-modal-header">
-          {list.title}
+          {listName}
           <button className="icon-button" onClick={onClose}>
             <CloseIcon />
           </button>
@@ -128,12 +130,12 @@ export function CardModal({
         </footer>
 
         <LabelMenu
-          cardLabels={cardLabels}
+          boardId={boardId}
+          listId={listId}
+          card={card}
           anchorEl={anchorEl}
           isLabelMenuOpen={isLabelMenuOpen}
           onCloseLabelMenu={() => setAnchorEl(null)}
-          listId={list.id}
-          card={card}
         />
       </Box>
     </Modal>

--- a/src/components/CardModal.jsx
+++ b/src/components/CardModal.jsx
@@ -130,6 +130,7 @@ export function CardModal({
         </footer>
 
         <LabelMenu
+          key={anchorEl ? "open" : "closed"}
           boardId={boardId}
           listId={listId}
           card={card}

--- a/src/components/CardModal.jsx
+++ b/src/components/CardModal.jsx
@@ -4,15 +4,27 @@ import CloseIcon from "@mui/icons-material/Close";
 import DeleteIcon from "@mui/icons-material/Delete";
 import AttachFileIcon from "@mui/icons-material/AttachFile";
 import AddIcon from "@mui/icons-material/Add";
+import { LabelMenu } from "./LabelMenu";
 
 export function CardModal({
   listTitle,
   cardLabels = [],
   card,
+  boardLabels = [],
   onClose,
   isOpen,
 }) {
   const [openSection, setOpenSection] = useState(false);
+  const [anchorEl, setAnchorEl] = useState(null);
+  const isLabelMenuOpen = Boolean(anchorEl);
+
+  function onOpenLabelMenu(event) {
+    setAnchorEl(event.currentTarget);
+  }
+
+  function onCloseLabelMenu() {
+    setAnchorEl(null);
+  }
 
   function handleCommentSection() {
     setOpenSection(!openSection);
@@ -33,7 +45,11 @@ export function CardModal({
           <section className="card-modal-content">
             <h1 className="card-modal-title">{card.title}</h1>
             <div className="card-modal-controls">
-              <button className="icon-button">
+              <button
+                className="icon-button"
+                onClick={onOpenLabelMenu}
+                selected={isLabelMenuOpen}
+              >
                 <AddIcon /> Add label
               </button>
               <button className="icon-button">
@@ -65,9 +81,8 @@ export function CardModal({
                 className="description-input"
                 placeholder="Add a description"
                 spellCheck="false"
-              >
-                {card.description}
-              </textarea>
+                defaultValue={card.description}
+              />
             </div>
           </section>
           <aside
@@ -92,6 +107,13 @@ export function CardModal({
             Comments
           </button>
         </footer>
+
+        <LabelMenu
+          boardLabels={boardLabels}
+          anchorEl={anchorEl}
+          isLabelMenuOpen={isLabelMenuOpen}
+          onCloseLabelMenu={onCloseLabelMenu}
+        />
       </Box>
     </Modal>
   );

--- a/src/components/CardModal.jsx
+++ b/src/components/CardModal.jsx
@@ -7,31 +7,20 @@ import AddIcon from "@mui/icons-material/Add";
 import { LabelMenu } from "./LabelMenu";
 
 export function CardModal({
-  listTitle,
-  cardLabels = [],
+  list,
   card,
-  boardLabels = [],
+  cardLabels = [],
+  onEditCard,
+  onDeleteCard,
   onClose,
   isOpen,
-  onDeleteCard,
-  onEditCard,
-  onSaveLabel,
   onRemoveLabel,
-  onUpdateCard,
 }) {
   const [openSection, setOpenSection] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const [cardDetails, setCardDetails] = useState(card);
   const [anchorEl, setAnchorEl] = useState(null);
   const isLabelMenuOpen = Boolean(anchorEl);
-
-  function onOpenLabelMenu(event) {
-    setAnchorEl(event.currentTarget);
-  }
-
-  function onCloseLabelMenu() {
-    setAnchorEl(null);
-  }
 
   function handleEditCard() {
     setIsEditing(true);
@@ -49,22 +38,16 @@ export function CardModal({
     setCardDetails({ ...cardDetails, [key]: value });
   }
 
+  function onOpenLabelMenu(event) {
+    setAnchorEl(event.currentTarget);
+  }
+
+  function onCloseLabelMenu() {
+    setAnchorEl(null);
+  }
+
   function handleToggleCardLabel(labelId) {
-    const currentLabelIds = card.labels || [];
-    let updatedLabelIds;
-
-    if (currentLabelIds.includes(labelId)) {
-      updatedLabelIds = currentLabelIds.filter(id => id !== labelId);
-    } else {
-      updatedLabelIds = [...currentLabelIds, labelId];
-    }
-
-    const updatedCard = {
-      ...card,
-      labels: updatedLabelIds,
-    };
-
-    onUpdateCard(updatedCard);
+    // onUpdateCard(updatedCard);
   }
 
   if (!card) return null;
@@ -73,7 +56,7 @@ export function CardModal({
     <Modal open={isOpen} onClose={onClose}>
       <Box className={`card-modal-box ${openSection ? "open" : "closed"}`}>
         <div className="card-modal-header">
-          {listTitle}
+          {list.title}
           <button className="icon-button" onClick={onClose}>
             <CloseIcon />
           </button>
@@ -158,14 +141,14 @@ export function CardModal({
         </footer>
 
         <LabelMenu
-          boardLabels={boardLabels}
           cardLabels={cardLabels}
           anchorEl={anchorEl}
           isLabelMenuOpen={isLabelMenuOpen}
           onCloseLabelMenu={onCloseLabelMenu}
-          onSaveLabel={onSaveLabel}
           onRemoveLabel={onRemoveLabel}
           onToggleCardLabel={handleToggleCardLabel}
+          listId={list.id}
+          card={card}
         />
       </Box>
     </Modal>

--- a/src/components/CardModal.jsx
+++ b/src/components/CardModal.jsx
@@ -9,7 +9,7 @@ import { LabelMenu } from "./LabelMenu";
 export function CardModal({
   boardId,
   listId,
-  listName,
+  listTitle,
   card,
   cardLabels = [],
   onEditCard,
@@ -45,7 +45,7 @@ export function CardModal({
     <Modal open={isOpen} onClose={onClose}>
       <Box className={`card-modal-box ${openSection ? "open" : "closed"}`}>
         <div className="card-modal-header">
-          {listName}
+          {listTitle}
           <button className="icon-button" onClick={onClose}>
             <CloseIcon />
           </button>

--- a/src/components/CardModal.jsx
+++ b/src/components/CardModal.jsx
@@ -37,18 +37,6 @@ export function CardModal({
     setCardDetails({ ...cardDetails, [key]: value });
   }
 
-  function onOpenLabelMenu(event) {
-    setAnchorEl(event.currentTarget);
-  }
-
-  function onCloseLabelMenu() {
-    setAnchorEl(null);
-  }
-
-  function handleToggleCardLabel(labelId) {
-    // onUpdateCard(updatedCard);
-  }
-
   if (!card) return null;
 
   return (
@@ -77,7 +65,7 @@ export function CardModal({
             <div className="card-modal-controls">
               <button
                 className="icon-button"
-                onClick={onOpenLabelMenu}
+                onClick={e => setAnchorEl(e.currentTarget)}
                 selected={isLabelMenuOpen}
               >
                 <AddIcon /> Add label
@@ -143,8 +131,7 @@ export function CardModal({
           cardLabels={cardLabels}
           anchorEl={anchorEl}
           isLabelMenuOpen={isLabelMenuOpen}
-          onCloseLabelMenu={onCloseLabelMenu}
-          onToggleCardLabel={handleToggleCardLabel}
+          onCloseLabelMenu={() => setAnchorEl(null)}
           listId={list.id}
           card={card}
         />

--- a/src/components/CardModal.jsx
+++ b/src/components/CardModal.jsx
@@ -14,7 +14,6 @@ export function CardModal({
   onDeleteCard,
   onClose,
   isOpen,
-  onRemoveLabel,
 }) {
   const [openSection, setOpenSection] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
@@ -145,7 +144,6 @@ export function CardModal({
           anchorEl={anchorEl}
           isLabelMenuOpen={isLabelMenuOpen}
           onCloseLabelMenu={onCloseLabelMenu}
-          onRemoveLabel={onRemoveLabel}
           onToggleCardLabel={handleToggleCardLabel}
           listId={list.id}
           card={card}

--- a/src/components/LabelEditor.jsx
+++ b/src/components/LabelEditor.jsx
@@ -27,19 +27,15 @@ export function LabelEditor({
   const isEditMode = existingLabel !== null;
 
   function handleSave() {
-    const labelData = isEditMode
-      ? {
-          ...existingLabel,
-          title,
-          color: selectedColor,
-        }
-      : {
-          ...boardService.getEmptyLabel(),
-          title,
-          color: selectedColor,
-        };
+    const baseLabel = isEditMode ? existingLabel : boardService.getEmptyLabel();
 
-    onSaveLabel(labelData);
+    const label = {
+      ...baseLabel,
+      title,
+      color: selectedColor,
+    };
+
+    onSaveLabel(label);
   }
 
   return (

--- a/src/components/LabelEditor.jsx
+++ b/src/components/LabelEditor.jsx
@@ -15,13 +15,13 @@ const colors = [
 ];
 
 export function LabelEditor({ labelToEdit, onSaveLabel, onDeleteLabel }) {
-  const [title, setTitle] = useState(labelToEdit?.title || "");
+  const [title, setTitle] = useState(labelToEdit.title);
   const [selectedColor, setSelectedColor] = useState(
-    labelToEdit?.color || colors[0]
+    labelToEdit.color || colors[0]
   );
 
   function handleSave() {
-    const label = labelToEdit || boardService.getEmptyLabel();
+    const label = labelToEdit.id ? labelToEdit : boardService.getEmptyLabel();
 
     const updatedLabel = {
       ...label,
@@ -67,9 +67,9 @@ export function LabelEditor({ labelToEdit, onSaveLabel, onDeleteLabel }) {
 
       <div className="label-editor-actions">
         <button className="save-btn" onClick={handleSave}>
-          {labelToEdit ? "Save" : "Create"}
+          {labelToEdit.id ? "Save" : "Create"}
         </button>
-        {labelToEdit && (
+        {labelToEdit.id && (
           <button
             className="delete-btn"
             onClick={() => onDeleteLabel(labelToEdit.id)}

--- a/src/components/LabelEditor.jsx
+++ b/src/components/LabelEditor.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { boardService } from "../services/board";
 
 const colors = [
   "green",
@@ -13,7 +14,11 @@ const colors = [
   "gray",
 ];
 
-export function LabelEditor({ existingLabel = null, onSave, onRemove }) {
+export function LabelEditor({
+  existingLabel = null,
+  onSaveLabel,
+  onRemoveLabel,
+}) {
   const isEditMode = existingLabel !== null;
 
   const [title, setTitle] = useState(existingLabel?.title || "");
@@ -22,28 +27,33 @@ export function LabelEditor({ existingLabel = null, onSave, onRemove }) {
   );
 
   function handleSave() {
-    const labelData = {
-      id: existingLabel?.id || Date.now().toString(),
-      title,
-      color: selectedColor,
-    };
-    onSave(labelData);
+    const labelData = isEditMode
+      ? {
+          ...existingLabel,
+          title,
+          color: selectedColor,
+        }
+      : {
+          ...boardService.getEmptyLabel(),
+          title,
+          color: selectedColor,
+        };
+
+    onSaveLabel(labelData);
   }
 
   function handleRemove() {
     if (existingLabel) {
-      onRemove(existingLabel.id);
+      onRemoveLabel(existingLabel.id);
     }
   }
 
   return (
     <div className="label-editor-content">
-      {/* Color Preview */}
       <div className={`label-preview label-color-option ${selectedColor}`}>
         {title}
       </div>
 
-      {/* Title Input */}
       <div className="label-editor-field">
         <label className="label-editor-label">Title</label>
         <input
@@ -56,7 +66,6 @@ export function LabelEditor({ existingLabel = null, onSave, onRemove }) {
         />
       </div>
 
-      {/* Color Selection */}
       <div className="label-editor-field">
         <label className="label-editor-label">Select a color</label>
         <div className="color-grid">
@@ -72,10 +81,8 @@ export function LabelEditor({ existingLabel = null, onSave, onRemove }) {
         </div>
       </div>
 
-      {/* Remove Color Option (optional) */}
       <button className="remove-color-btn">✕ Remove color</button>
 
-      {/* Action Buttons */}
       <div className="label-editor-actions">
         <button className="save-btn" onClick={handleSave}>
           {isEditMode ? "Save" : "Create"}

--- a/src/components/LabelEditor.jsx
+++ b/src/components/LabelEditor.jsx
@@ -17,7 +17,7 @@ const colors = [
 export function LabelEditor({
   existingLabel = null,
   onSaveLabel,
-  onRemoveLabel,
+  onDeleteLabel,
 }) {
   const [title, setTitle] = useState(existingLabel?.title || "");
   const [selectedColor, setSelectedColor] = useState(
@@ -40,12 +40,6 @@ export function LabelEditor({
         };
 
     onSaveLabel(labelData);
-  }
-
-  function handleRemove() {
-    if (existingLabel) {
-      onRemoveLabel(existingLabel.id);
-    }
   }
 
   return (
@@ -86,7 +80,10 @@ export function LabelEditor({
           {isEditMode ? "Save" : "Create"}
         </button>
         {isEditMode && (
-          <button className="delete-btn" onClick={handleRemove}>
+          <button
+            className="delete-btn"
+            onClick={() => onDeleteLabel(existingLabel?.id)}
+          >
             Delete
           </button>
         )}

--- a/src/components/LabelEditor.jsx
+++ b/src/components/LabelEditor.jsx
@@ -81,8 +81,6 @@ export function LabelEditor({
         </div>
       </div>
 
-      <button className="remove-color-btn">✕ Remove color</button>
-
       <div className="label-editor-actions">
         <button className="save-btn" onClick={handleSave}>
           {isEditMode ? "Save" : "Create"}

--- a/src/components/LabelEditor.jsx
+++ b/src/components/LabelEditor.jsx
@@ -14,28 +14,22 @@ const colors = [
   "gray",
 ];
 
-export function LabelEditor({
-  existingLabel = null,
-  onSaveLabel,
-  onDeleteLabel,
-}) {
-  const [title, setTitle] = useState(existingLabel?.title || "");
+export function LabelEditor({ labelToEdit, onSaveLabel, onDeleteLabel }) {
+  const [title, setTitle] = useState(labelToEdit?.title || "");
   const [selectedColor, setSelectedColor] = useState(
-    existingLabel?.color || colors[0]
+    labelToEdit?.color || colors[0]
   );
 
-  const isEditMode = existingLabel !== null;
-
   function handleSave() {
-    const baseLabel = isEditMode ? existingLabel : boardService.getEmptyLabel();
+    const label = labelToEdit || boardService.getEmptyLabel();
 
-    const label = {
-      ...baseLabel,
+    const updatedLabel = {
+      ...label,
       title,
       color: selectedColor,
     };
 
-    onSaveLabel(label);
+    onSaveLabel(updatedLabel);
   }
 
   return (
@@ -73,12 +67,12 @@ export function LabelEditor({
 
       <div className="label-editor-actions">
         <button className="save-btn" onClick={handleSave}>
-          {isEditMode ? "Save" : "Create"}
+          {labelToEdit ? "Save" : "Create"}
         </button>
-        {isEditMode && (
+        {labelToEdit && (
           <button
             className="delete-btn"
-            onClick={() => onDeleteLabel(existingLabel?.id)}
+            onClick={() => onDeleteLabel(labelToEdit.id)}
           >
             Delete
           </button>

--- a/src/components/LabelEditor.jsx
+++ b/src/components/LabelEditor.jsx
@@ -1,0 +1,91 @@
+import { useState } from "react";
+
+const colors = [
+  "green",
+  "yellow",
+  "orange",
+  "red",
+  "purple",
+  "blue",
+  "sky",
+  "lime",
+  "pink",
+  "gray",
+];
+
+export function LabelEditor({ existingLabel = null, onSave, onRemove }) {
+  const isEditMode = existingLabel !== null;
+
+  const [title, setTitle] = useState(existingLabel?.title || "");
+  const [selectedColor, setSelectedColor] = useState(
+    existingLabel?.color || colors[0]
+  );
+
+  function handleSave() {
+    const labelData = {
+      id: existingLabel?.id || Date.now().toString(),
+      title,
+      color: selectedColor,
+    };
+    onSave(labelData);
+  }
+
+  function handleRemove() {
+    if (existingLabel) {
+      onRemove(existingLabel.id);
+    }
+  }
+
+  return (
+    <div className="label-editor-content">
+      {/* Color Preview */}
+      <div className={`label-preview label-color-option ${selectedColor}`}>
+        {title}
+      </div>
+
+      {/* Title Input */}
+      <div className="label-editor-field">
+        <label className="label-editor-label">Title</label>
+        <input
+          type="text"
+          className="label-editor-input"
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          placeholder="Enter label title"
+          autoFocus
+        />
+      </div>
+
+      {/* Color Selection */}
+      <div className="label-editor-field">
+        <label className="label-editor-label">Select a color</label>
+        <div className="color-grid">
+          {colors.map(color => (
+            <button
+              key={color}
+              className={`label-color-option ${color} ${
+                selectedColor === color ? "selected" : ""
+              }`}
+              onClick={() => setSelectedColor(color)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Remove Color Option (optional) */}
+      <button className="remove-color-btn">✕ Remove color</button>
+
+      {/* Action Buttons */}
+      <div className="label-editor-actions">
+        <button className="save-btn" onClick={handleSave}>
+          {isEditMode ? "Save" : "Create"}
+        </button>
+        {isEditMode && (
+          <button className="delete-btn" onClick={handleRemove}>
+            Delete
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/LabelEditor.jsx
+++ b/src/components/LabelEditor.jsx
@@ -19,12 +19,12 @@ export function LabelEditor({
   onSaveLabel,
   onRemoveLabel,
 }) {
-  const isEditMode = existingLabel !== null;
-
   const [title, setTitle] = useState(existingLabel?.title || "");
   const [selectedColor, setSelectedColor] = useState(
     existingLabel?.color || colors[0]
   );
+
+  const isEditMode = existingLabel !== null;
 
   function handleSave() {
     const labelData = isEditMode

--- a/src/components/LabelMenu.jsx
+++ b/src/components/LabelMenu.jsx
@@ -37,6 +37,13 @@ export function LabelMenu({
     setViewEditor(false);
   }
 
+  function handleCloseLabelMenu() {
+    setSearchTerm("");
+    setLabelToEdit(null);
+    setViewEditor(false);
+    onCloseLabelMenu();
+  }
+
   async function handleCreateLabel(label) {
     await createLabel(boardId, label);
     handleToggleLabel(label.id);
@@ -86,6 +93,7 @@ export function LabelMenu({
         horizontal: "left",
       }}
       paperProps={{ sx: { mt: 1 } }}
+      slotProps={{ transition: { onExited: () => handleCloseLabelMenu() } }}
     >
       {viewEditor ? (
         <LabelEditor

--- a/src/components/LabelMenu.jsx
+++ b/src/components/LabelMenu.jsx
@@ -27,12 +27,7 @@ export function LabelMenu({
     label.title.toLowerCase().includes(searchTerm.toLowerCase())
   );
 
-  function handleShowCreateLabel() {
-    setLabelToEdit(null);
-    setViewEditor(true);
-  }
-
-  function handleShowEditLabel(label) {
+  function handleShowEditor(label) {
     setLabelToEdit(label);
     setViewEditor(true);
   }
@@ -42,28 +37,29 @@ export function LabelMenu({
     setViewEditor(false);
   }
 
-  function onCreateLabel(label) {
-    createLabel(boardId, label);
-    onToggleLabel(label.id);
+  async function handleCreateLabel(label) {
+    await createLabel(boardId, label);
+    handleToggleLabel(label.id);
+    setSearchTerm("");
     handleBack();
   }
 
-  function onEditLabel(label) {
+  function handleEditLabel(label) {
     editLabel(boardId, label);
     handleBack();
   }
 
-  function onDeleteLabel(labelId) {
-    deleteLabel(boardId, labelId);
+  async function handleDeleteLabel(labelId) {
+    await deleteLabel(boardId, labelId);
 
     if (card.labels.includes(labelId)) {
-      onToggleLabel(labelId);
+      handleToggleLabel(labelId);
     }
 
     handleBack();
   }
 
-  function onToggleLabel(labelId) {
+  function handleToggleLabel(labelId) {
     const updatedCardLabels = card.labels.includes(labelId)
       ? card.labels.filter(id => id !== labelId)
       : [...card.labels, labelId];
@@ -73,7 +69,7 @@ export function LabelMenu({
 
   function getPopoverTitle() {
     if (!viewEditor) return "Labels";
-    return labelToEdit ? "Edit label" : "Create label";
+    return labelToEdit.id ? "Edit label" : "Create label";
   }
 
   return (
@@ -94,8 +90,8 @@ export function LabelMenu({
       {viewEditor ? (
         <LabelEditor
           labelToEdit={labelToEdit}
-          onSaveLabel={labelToEdit ? onEditLabel : onCreateLabel}
-          onDeleteLabel={onDeleteLabel}
+          onSaveLabel={labelToEdit.id ? handleEditLabel : handleCreateLabel}
+          onDeleteLabel={handleDeleteLabel}
         />
       ) : (
         <div className="label-menu-content">
@@ -121,8 +117,8 @@ export function LabelMenu({
                     <LabelMenuItem
                       label={label}
                       isChecked={isChecked}
-                      onToggleLabel={onToggleLabel}
-                      onShowEditLabel={handleShowEditLabel}
+                      onToggleLabel={handleToggleLabel}
+                      onShowEditor={handleShowEditor}
                     />
                   </li>
                 );
@@ -132,7 +128,10 @@ export function LabelMenu({
             )}
           </ul>
 
-          <button className="create-label-btn" onClick={handleShowCreateLabel}>
+          <button
+            className="create-label-btn"
+            onClick={() => handleShowEditor({ title: searchTerm })}
+          >
             Create a new label
           </button>
         </div>

--- a/src/components/LabelMenu.jsx
+++ b/src/components/LabelMenu.jsx
@@ -78,7 +78,7 @@ export function LabelMenu({
       anchorEl={anchorEl}
       isOpen={isLabelMenuOpen}
       onClose={handleCloseMenu}
-      title={getPopoverTitle}
+      title={getPopoverTitle()}
       showBack={view}
       onBack={view === "editor" ? handleBack : handleCloseMenu}
       anchorOrigin={{

--- a/src/components/LabelMenu.jsx
+++ b/src/components/LabelMenu.jsx
@@ -56,7 +56,7 @@ export function LabelMenu({
     onCloseLabelMenu();
   }
 
-  async function handleSaveLabel(labelData) {
+  function handleSaveLabel(labelData) {
     try {
       const labelDataId = labelData?.id;
 
@@ -66,7 +66,7 @@ export function LabelMenu({
 
       if (!editingLabel) {
         const updatedCard = getUpdatedCard(labelDataId);
-        await addNewLabelToCard(
+        addNewLabelToCard(
           board._id,
           boardUpdates,
           boardOptions,
@@ -74,7 +74,7 @@ export function LabelMenu({
           listId
         );
       } else {
-        await updateBoard(board._id, boardUpdates, boardOptions);
+        updateBoard(board._id, boardUpdates, boardOptions);
       }
 
       const successMsgText = `Label "${labelData.title}" saved successfully!`;
@@ -114,14 +114,14 @@ export function LabelMenu({
     return { ...card, labels: updatedLabelIds };
   }
 
-  async function handleDeleteLabel(labelId) {
+  function handleDeleteLabel(labelId) {
     try {
       const boardLabels = board.labels || [];
       const updatedBoardLabels = boardLabels.filter(l => l.id !== labelId);
       const updates = { labels: updatedBoardLabels };
       const options = { listId: null, cardId: null };
 
-      await updateBoard(board._id, updates, options);
+      updateBoard(board._id, updates, options);
       showSuccessMsg("Label removed successfully!");
       handleBack();
     } catch (error) {

--- a/src/components/LabelMenu.jsx
+++ b/src/components/LabelMenu.jsx
@@ -3,11 +3,7 @@ import { useSelector } from "react-redux";
 import { Popover } from "./Popover";
 import { LabelMenuItem } from "./LabelMenuItem";
 import { LabelEditor } from "./LabelEditor";
-import {
-  addNewLabelToCard,
-  editCard,
-  updateBoard,
-} from "../store/actions/board-actions";
+import { editCard, updateBoard } from "../store/actions/board-actions";
 import { showErrorMsg, showSuccessMsg } from "../services/event-bus-service";
 
 export function LabelMenu({
@@ -59,7 +55,7 @@ export function LabelMenu({
     onCloseLabelMenu();
   }
 
-  function handleSaveLabel(labelData) {
+  async function handleSaveLabel(labelData) {
     try {
       const labelDataId = labelData?.id;
 
@@ -67,17 +63,10 @@ export function LabelMenu({
       const boardUpdates = { labels: updatedBoardLabels };
       const boardOptions = { listId: null, cardId: null };
 
+      await updateBoard(board._id, boardUpdates, boardOptions);
       if (!editingLabel) {
         const updatedCard = getUpdatedCard(labelDataId);
-        addNewLabelToCard(
-          board._id,
-          boardUpdates,
-          boardOptions,
-          updatedCard,
-          listId
-        );
-      } else {
-        updateBoard(board._id, boardUpdates, boardOptions);
+        editCard(board._id, updatedCard, listId);
       }
 
       const successMsgText = `Label "${labelData.title}" saved successfully!`;
@@ -134,8 +123,13 @@ export function LabelMenu({
   }
 
   function handleToggleLabel(labelId) {
-    const updatedCard = getUpdatedCard(labelId);
-    editCard(board._id, updatedCard, listId);
+    try {
+      const updatedCard = getUpdatedCard(labelId);
+      editCard(board._id, updatedCard, listId);
+    } catch (error) {
+      console.error("Label toggling failed:", error);
+      showErrorMsg("Unable to toggle label");
+    }
   }
 
   return (

--- a/src/components/LabelMenu.jsx
+++ b/src/components/LabelMenu.jsx
@@ -5,16 +5,17 @@ import { LabelEditor } from "./LabelEditor";
 
 export function LabelMenu({
   boardLabels,
+  cardLabels = [],
   anchorEl,
   isLabelMenuOpen,
   onCloseLabelMenu,
   onSaveLabel,
   onRemoveLabel,
+  onToggleCardLabel,
 }) {
-  const [view, setView] = useState("list"); // "list" or "editor"
+  const [view, setView] = useState("list");
   const [editingLabel, setEditingLabel] = useState(null);
 
-  // Reset view to "list" when menu opens
   useEffect(() => {
     if (isLabelMenuOpen) {
       setView("list");
@@ -23,12 +24,12 @@ export function LabelMenu({
   }, [isLabelMenuOpen]);
 
   function handleCreateLabel() {
-    setEditingLabel(null); // null = create mode
+    setEditingLabel(null);
     setView("editor");
   }
 
   function handleEditLabel(label) {
-    setEditingLabel(label); // existing label = edit mode
+    setEditingLabel(label);
     setView("editor");
   }
 
@@ -43,12 +44,21 @@ export function LabelMenu({
 
   function handleSaveLabel(labelData) {
     onSaveLabel(labelData);
+
+    if (!editingLabel) {
+      onToggleCardLabel(labelData.id);
+    }
+
     handleBack();
   }
 
   function handleRemoveLabel(labelId) {
     onRemoveLabel(labelId);
     handleBack();
+  }
+
+  function handleToggleLabel(labelId) {
+    onToggleCardLabel(labelId);
   }
 
   return (
@@ -65,7 +75,7 @@ export function LabelMenu({
           : "Create label"
       }
       showBack={view}
-      onBack={handleBack}
+      onBack={view === "editor" ? handleBack : handleCloseMenu}
       anchorOrigin={{
         vertical: "bottom",
         horizontal: "left",
@@ -84,14 +94,21 @@ export function LabelMenu({
           <label className="label-menu-label">Labels</label>
 
           <ul className="labels-list">
-            {boardLabels.map(label => (
-              <li key={label.id}>
-                <LabelMenuItem
-                  label={label}
-                  onEdit={() => handleEditLabel(label)}
-                />
-              </li>
-            ))}
+            {boardLabels.map(label => {
+              const isChecked = cardLabels.some(
+                cardLabel => cardLabel.id === label.id
+              );
+              return (
+                <li key={label.id}>
+                  <LabelMenuItem
+                    label={label}
+                    isChecked={isChecked}
+                    onToggle={handleToggleLabel}
+                    onEdit={() => handleEditLabel(label)}
+                  />
+                </li>
+              );
+            })}
           </ul>
 
           <button className="create-label-btn" onClick={handleCreateLabel}>
@@ -101,8 +118,8 @@ export function LabelMenu({
       ) : (
         <LabelEditor
           existingLabel={editingLabel}
-          onSave={handleSaveLabel}
-          onRemove={handleRemoveLabel}
+          onSaveLabel={handleSaveLabel}
+          onRemoveLabel={handleRemoveLabel}
         />
       )}
     </Popover>

--- a/src/components/LabelMenu.jsx
+++ b/src/components/LabelMenu.jsx
@@ -29,6 +29,11 @@ export function LabelMenu({
     }
   }, [isLabelMenuOpen]);
 
+  function getPopoverTitle() {
+    if (view === "list") return "Labels";
+    return editingLabel ? "Edit label" : "Create label";
+  }
+
   function handleCreateLabel() {
     setEditingLabel(null);
     setView("editor");
@@ -73,13 +78,7 @@ export function LabelMenu({
       anchorEl={anchorEl}
       isOpen={isLabelMenuOpen}
       onClose={handleCloseMenu}
-      title={
-        view === "list"
-          ? "Labels"
-          : editingLabel
-          ? "Edit label"
-          : "Create label"
-      }
+      title={getPopoverTitle}
       showBack={view}
       onBack={view === "editor" ? handleBack : handleCloseMenu}
       anchorOrigin={{

--- a/src/components/LabelMenu.jsx
+++ b/src/components/LabelMenu.jsx
@@ -11,7 +11,6 @@ export function LabelMenu({
   anchorEl,
   isLabelMenuOpen,
   onCloseLabelMenu,
-  onRemoveLabel,
   onToggleCardLabel,
   listId,
   card,
@@ -57,7 +56,7 @@ export function LabelMenu({
     onCloseLabelMenu();
   }
 
-  function handleSaveLabel(labelData) {
+  async function handleSaveLabel(labelData) {
     try {
       const labelDataId = labelData?.id;
 
@@ -67,7 +66,7 @@ export function LabelMenu({
 
       if (!editingLabel) {
         const updatedCard = getUpdatedCard(labelDataId);
-        addNewLabelToCard(
+        await addNewLabelToCard(
           board._id,
           boardUpdates,
           boardOptions,
@@ -75,7 +74,7 @@ export function LabelMenu({
           listId
         );
       } else {
-        updateBoard(board._id, boardUpdates, boardOptions);
+        await updateBoard(board._id, boardUpdates, boardOptions);
       }
 
       const successMsgText = `Label "${labelData.title}" saved successfully!`;
@@ -115,9 +114,20 @@ export function LabelMenu({
     return { ...card, labels: updatedLabelIds };
   }
 
-  function handleRemoveLabel(labelId) {
-    onRemoveLabel(labelId);
-    handleBack();
+  async function handleDeleteLabel(labelId) {
+    try {
+      const boardLabels = board.labels || [];
+      const updatedBoardLabels = boardLabels.filter(l => l.id !== labelId);
+      const updates = { labels: updatedBoardLabels };
+      const options = { listId: null, cardId: null };
+
+      await updateBoard(board._id, updates, options);
+      showSuccessMsg("Label removed successfully!");
+      handleBack();
+    } catch (error) {
+      console.error("Label removal failed:", error);
+      showErrorMsg("Unable to remove label");
+    }
   }
 
   function handleToggleLabel(labelId) {
@@ -182,7 +192,7 @@ export function LabelMenu({
         <LabelEditor
           existingLabel={editingLabel}
           onSaveLabel={handleSaveLabel}
-          onRemoveLabel={handleRemoveLabel}
+          onDeleteLabel={handleDeleteLabel}
         />
       )}
     </Popover>

--- a/src/components/LabelMenu.jsx
+++ b/src/components/LabelMenu.jsx
@@ -3,7 +3,11 @@ import { useSelector } from "react-redux";
 import { Popover } from "./Popover";
 import { LabelMenuItem } from "./LabelMenuItem";
 import { LabelEditor } from "./LabelEditor";
-import { addNewLabelToCard, updateBoard } from "../store/actions/board-actions";
+import {
+  addNewLabelToCard,
+  editCard,
+  updateBoard,
+} from "../store/actions/board-actions";
 import { showErrorMsg, showSuccessMsg } from "../services/event-bus-service";
 
 export function LabelMenu({
@@ -11,7 +15,6 @@ export function LabelMenu({
   anchorEl,
   isLabelMenuOpen,
   onCloseLabelMenu,
-  onToggleCardLabel,
   listId,
   card,
 }) {
@@ -131,7 +134,8 @@ export function LabelMenu({
   }
 
   function handleToggleLabel(labelId) {
-    onToggleCardLabel(labelId);
+    const updatedCard = getUpdatedCard(labelId);
+    editCard(board._id, updatedCard, listId);
   }
 
   return (
@@ -173,7 +177,7 @@ export function LabelMenu({
                     <LabelMenuItem
                       label={label}
                       isChecked={isChecked}
-                      onToggle={handleToggleLabel}
+                      onToggleLabel={handleToggleLabel}
                       onEdit={() => handleEditLabel(label)}
                     />
                   </li>

--- a/src/components/LabelMenu.jsx
+++ b/src/components/LabelMenu.jsx
@@ -1,17 +1,45 @@
-import { Box } from "@mui/material";
+import { Popover } from "./Popover";
 import { LabelMenuItem } from "./LabelMenuItem";
 
-export function LabelMenu({ boardLabels }) {
+export function LabelMenu({
+  boardLabels,
+  anchorEl,
+  isLabelMenuOpen,
+  onCloseLabelMenu,
+}) {
   return (
-    <section className="label-menu card-content">
-      <h3>Labels</h3>
-      <ul className="labels-list">
-        {boardLabels.map(label => (
-          <li key={label.id}>
-            <LabelMenuItem key={label.id} label={label} />
-          </li>
-        ))}
-      </ul>
-    </section>
+    <Popover
+      className="label-menu-popover"
+      anchorEl={anchorEl}
+      open={isLabelMenuOpen}
+      onClose={onCloseLabelMenu}
+      title="Labels"
+      anchorOrigin={{
+        vertical: "bottom",
+        horizontal: "left",
+      }}
+      paperProps={{ sx: { mt: 1 } }}
+    >
+      <div className="label-menu-content">
+        <input
+          type="text"
+          className="label-search"
+          placeholder="Search labels..."
+          autoFocus
+        />
+
+        <h3>Labels</h3>
+
+        <ul className="labels-list">
+          {boardLabels.map(label => (
+            <li key={label.id}>
+              <LabelMenuItem label={label} />
+            </li>
+          ))}
+        </ul>
+
+        <button className="create-label-btn">Create a new label</button>
+      </div>
+    </Popover>
   );
 }

--- a/src/components/LabelMenu.jsx
+++ b/src/components/LabelMenu.jsx
@@ -3,7 +3,7 @@ import { useSelector } from "react-redux";
 import { Popover } from "./Popover";
 import { LabelMenuItem } from "./LabelMenuItem";
 import { LabelEditor } from "./LabelEditor";
-import { addLabel } from "../store/actions/board-actions";
+import { addNewLabelToCard, updateBoard } from "../store/actions/board-actions";
 import { showErrorMsg, showSuccessMsg } from "../services/event-bus-service";
 
 export function LabelMenu({
@@ -57,24 +57,29 @@ export function LabelMenu({
     onCloseLabelMenu();
   }
 
-  async function handleSaveLabel(labelData) {
+  function handleSaveLabel(labelData) {
     try {
       const labelDataId = labelData?.id;
 
       const updatedBoardLabels = getUpdatedBoardLabels(labelData);
       const boardUpdates = { labels: updatedBoardLabels };
       const boardOptions = { listId: null, cardId: null };
-      const updatedCard = getUpdatedCard(labelDataId);
 
-      addLabel(board._id, boardUpdates, boardOptions, updatedCard, listId);
+      if (!editingLabel) {
+        const updatedCard = getUpdatedCard(labelDataId);
+        addNewLabelToCard(
+          board._id,
+          boardUpdates,
+          boardOptions,
+          updatedCard,
+          listId
+        );
+      } else {
+        updateBoard(board._id, boardUpdates, boardOptions);
+      }
 
       const successMsgText = `Label "${labelData.title}" saved successfully!`;
       showSuccessMsg(successMsgText);
-
-      // if (!editingLabel) {
-      //   onToggleCardLabel(labelDataId);
-      // }
-
       handleBack();
     } catch (error) {
       console.error("Label save failed:", error);

--- a/src/components/LabelMenu.jsx
+++ b/src/components/LabelMenu.jsx
@@ -1,45 +1,110 @@
+import { useState, useEffect } from "react";
 import { Popover } from "./Popover";
 import { LabelMenuItem } from "./LabelMenuItem";
+import { LabelEditor } from "./LabelEditor";
 
 export function LabelMenu({
   boardLabels,
   anchorEl,
   isLabelMenuOpen,
   onCloseLabelMenu,
+  onSaveLabel,
+  onRemoveLabel,
 }) {
+  const [view, setView] = useState("list"); // "list" or "editor"
+  const [editingLabel, setEditingLabel] = useState(null);
+
+  // Reset view to "list" when menu opens
+  useEffect(() => {
+    if (isLabelMenuOpen) {
+      setView("list");
+      setEditingLabel(null);
+    }
+  }, [isLabelMenuOpen]);
+
+  function handleCreateLabel() {
+    setEditingLabel(null); // null = create mode
+    setView("editor");
+  }
+
+  function handleEditLabel(label) {
+    setEditingLabel(label); // existing label = edit mode
+    setView("editor");
+  }
+
+  function handleBack() {
+    setView("list");
+    setEditingLabel(null);
+  }
+
+  function handleCloseMenu() {
+    onCloseLabelMenu();
+  }
+
+  function handleSaveLabel(labelData) {
+    onSaveLabel(labelData);
+    handleBack();
+  }
+
+  function handleRemoveLabel(labelId) {
+    onRemoveLabel(labelId);
+    handleBack();
+  }
+
   return (
     <Popover
       className="label-menu-popover"
       anchorEl={anchorEl}
-      open={isLabelMenuOpen}
-      onClose={onCloseLabelMenu}
-      title="Labels"
+      isOpen={isLabelMenuOpen}
+      onClose={handleCloseMenu}
+      title={
+        view === "list"
+          ? "Labels"
+          : editingLabel
+          ? "Edit label"
+          : "Create label"
+      }
+      showBack={view}
+      onBack={handleBack}
       anchorOrigin={{
         vertical: "bottom",
         horizontal: "left",
       }}
       paperProps={{ sx: { mt: 1 } }}
     >
-      <div className="label-menu-content">
-        <input
-          type="text"
-          className="label-search"
-          placeholder="Search labels..."
-          autoFocus
+      {view === "list" ? (
+        <div className="label-menu-content">
+          <input
+            type="text"
+            className="label-search"
+            placeholder="Search labels..."
+            autoFocus
+          />
+
+          <label className="label-menu-label">Labels</label>
+
+          <ul className="labels-list">
+            {boardLabels.map(label => (
+              <li key={label.id}>
+                <LabelMenuItem
+                  label={label}
+                  onEdit={() => handleEditLabel(label)}
+                />
+              </li>
+            ))}
+          </ul>
+
+          <button className="create-label-btn" onClick={handleCreateLabel}>
+            Create a new label
+          </button>
+        </div>
+      ) : (
+        <LabelEditor
+          existingLabel={editingLabel}
+          onSave={handleSaveLabel}
+          onRemove={handleRemoveLabel}
         />
-
-        <h3>Labels</h3>
-
-        <ul className="labels-list">
-          {boardLabels.map(label => (
-            <li key={label.id}>
-              <LabelMenuItem label={label} />
-            </li>
-          ))}
-        </ul>
-
-        <button className="create-label-btn">Create a new label</button>
-      </div>
+      )}
     </Popover>
   );
 }

--- a/src/components/LabelMenu.jsx
+++ b/src/components/LabelMenu.jsx
@@ -15,11 +15,17 @@ export function LabelMenu({
 }) {
   const [view, setView] = useState("list");
   const [editingLabel, setEditingLabel] = useState(null);
+  const [searchTerm, setSearchTerm] = useState("");
+
+  const filteredLabels = boardLabels.filter(label =>
+    label.title.toLowerCase().includes(searchTerm.toLowerCase())
+  );
 
   useEffect(() => {
     if (isLabelMenuOpen) {
       setView("list");
       setEditingLabel(null);
+      setSearchTerm("");
     }
   }, [isLabelMenuOpen]);
 
@@ -88,27 +94,33 @@ export function LabelMenu({
             type="text"
             className="label-search"
             placeholder="Search labels..."
+            value={searchTerm}
+            onChange={e => setSearchTerm(e.target.value)}
             autoFocus
           />
 
           <label className="label-menu-label">Labels</label>
 
           <ul className="labels-list">
-            {boardLabels.map(label => {
-              const isChecked = cardLabels.some(
-                cardLabel => cardLabel.id === label.id
-              );
-              return (
-                <li key={label.id}>
-                  <LabelMenuItem
-                    label={label}
-                    isChecked={isChecked}
-                    onToggle={handleToggleLabel}
-                    onEdit={() => handleEditLabel(label)}
-                  />
-                </li>
-              );
-            })}
+            {filteredLabels.length > 0 ? (
+              filteredLabels.map(label => {
+                const isChecked = cardLabels.some(
+                  cardLabel => cardLabel.id === label.id
+                );
+                return (
+                  <li key={label.id}>
+                    <LabelMenuItem
+                      label={label}
+                      isChecked={isChecked}
+                      onToggle={handleToggleLabel}
+                      onEdit={() => handleEditLabel(label)}
+                    />
+                  </li>
+                );
+              })
+            ) : (
+              <li className="no-labels-found">No labels found</li>
+            )}
           </ul>
 
           <button className="create-label-btn" onClick={handleCreateLabel}>

--- a/src/components/LabelMenu.jsx
+++ b/src/components/LabelMenu.jsx
@@ -1,0 +1,17 @@
+import { Box } from "@mui/material";
+import { LabelMenuItem } from "./LabelMenuItem";
+
+export function LabelMenu({ boardLabels }) {
+  return (
+    <section className="label-menu card-content">
+      <h3>Labels</h3>
+      <ul className="labels-list">
+        {boardLabels.map(label => (
+          <li key={label.id}>
+            <LabelMenuItem key={label.id} label={label} />
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/LabelMenuItem.jsx
+++ b/src/components/LabelMenuItem.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import Edit from "@mui/icons-material/Edit";
 
 export function LabelMenuItem({ label, isChecked, onToggleLabel, onEdit }) {
   return (
@@ -21,21 +21,7 @@ export function LabelMenuItem({ label, isChecked, onToggleLabel, onEdit }) {
         aria-label="Edit label"
         onClick={onEdit}
       >
-        <svg
-          width="24"
-          height="24"
-          role="presentation"
-          focusable="false"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            fillRule="evenodd"
-            clipRule="evenodd"
-            d="M7.82034 14.4893L9.94134 16.6103L18.4303 8.12131L16.3093 6.00031H16.3073L7.82034 14.4893ZM17.7233 4.58531L19.8443 6.70731C20.6253 7.48831 20.6253 8.7543 19.8443 9.53531L10.0873 19.2933L5.13734 14.3433L14.8943 4.58531C15.2853 4.19531 15.7973 4.00031 16.3093 4.00031C16.8203 4.00031 17.3323 4.19531 17.7233 4.58531ZM5.20094 20.4097C4.49794 20.5537 3.87694 19.9327 4.02094 19.2297L4.80094 15.4207L9.00994 19.6297L5.20094 20.4097Z"
-            fill="currentColor"
-          ></path>
-        </svg>
+        <Edit />
       </button>
     </div>
   );

--- a/src/components/LabelMenuItem.jsx
+++ b/src/components/LabelMenuItem.jsx
@@ -1,6 +1,11 @@
 import Edit from "@mui/icons-material/Edit";
 
-export function LabelMenuItem({ label, isChecked, onToggleLabel, onEdit }) {
+export function LabelMenuItem({
+  label,
+  isChecked,
+  onToggleLabel,
+  onShowEditLabel,
+}) {
   return (
     <div className="label-menu-item">
       <input
@@ -19,7 +24,7 @@ export function LabelMenuItem({ label, isChecked, onToggleLabel, onEdit }) {
       <button
         className="label-edit-btn"
         aria-label="Edit label"
-        onClick={onEdit}
+        onClick={() => onShowEditLabel(label)}
       >
         <Edit />
       </button>

--- a/src/components/LabelMenuItem.jsx
+++ b/src/components/LabelMenuItem.jsx
@@ -1,8 +1,45 @@
-export function LabelMenuItem() {
+import { useState } from "react";
+
+export function LabelMenuItem({ label }) {
+  const [isSelected, setIsSelected] = useState(false);
+
+  const handleToggle = () => {
+    setIsSelected(!isSelected);
+  };
+
   return (
-    <section className="label-menu-item">
-      <h3>Label Menu Item</h3>
-      <input type="checkbox" id="option1" name="options" value="value1"></input>
-    </section>
+    <div className="label-menu-item">
+      <input
+        type="checkbox"
+        id={`label-${label.id}`}
+        checked={isSelected}
+        onChange={handleToggle}
+        className="label-checkbox"
+      />
+      <label
+        htmlFor={`label-${label.id}`}
+        className="label-color-box"
+        style={{ backgroundColor: label.color }}
+      >
+        {label.title && <span className="label-title">{label.title}</span>}
+      </label>
+      <button className="label-edit-btn" aria-label="Edit label">
+        <svg
+          width="24"
+          height="24"
+          role="presentation"
+          focusable="false"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M7.82034 14.4893L9.94134 16.6103L18.4303 8.12131L16.3093 6.00031H16.3073L7.82034 14.4893ZM17.7233 4.58531L19.8443 6.70731C20.6253 7.48831 20.6253 8.7543 19.8443 9.53531L10.0873 19.2933L5.13734 14.3433L14.8943 4.58531C15.2853 4.19531 15.7973 4.00031 16.3093 4.00031C16.8203 4.00031 17.3323 4.19531 17.7233 4.58531ZM5.20094 20.4097C4.49794 20.5537 3.87694 19.9327 4.02094 19.2297L4.80094 15.4207L9.00994 19.6297L5.20094 20.4097Z"
+            fill="currentColor"
+          ></path>
+        </svg>
+      </button>
+    </div>
   );
 }

--- a/src/components/LabelMenuItem.jsx
+++ b/src/components/LabelMenuItem.jsx
@@ -1,0 +1,8 @@
+export function LabelMenuItem() {
+  return (
+    <section className="label-menu-item">
+      <h3>Label Menu Item</h3>
+      <input type="checkbox" id="option1" name="options" value="value1"></input>
+    </section>
+  );
+}

--- a/src/components/LabelMenuItem.jsx
+++ b/src/components/LabelMenuItem.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-export function LabelMenuItem({ label }) {
+export function LabelMenuItem({ label, onEdit }) {
   const [isSelected, setIsSelected] = useState(false);
 
   const handleToggle = () => {
@@ -18,12 +18,16 @@ export function LabelMenuItem({ label }) {
       />
       <label
         htmlFor={`label-${label.id}`}
-        className="label-color-box"
+        className={`label-color-box ${label.color}`}
         style={{ backgroundColor: label.color }}
       >
         {label.title && <span className="label-title">{label.title}</span>}
       </label>
-      <button className="label-edit-btn" aria-label="Edit label">
+      <button
+        className="label-edit-btn"
+        aria-label="Edit label"
+        onClick={onEdit}
+      >
         <svg
           width="24"
           height="24"

--- a/src/components/LabelMenuItem.jsx
+++ b/src/components/LabelMenuItem.jsx
@@ -4,7 +4,7 @@ export function LabelMenuItem({
   label,
   isChecked,
   onToggleLabel,
-  onShowEditLabel,
+  onShowEditor,
 }) {
   return (
     <div className="label-menu-item">
@@ -24,7 +24,7 @@ export function LabelMenuItem({
       <button
         className="label-edit-btn"
         aria-label="Edit label"
-        onClick={() => onShowEditLabel(label)}
+        onClick={() => onShowEditor(label)}
       >
         <Edit />
       </button>

--- a/src/components/LabelMenuItem.jsx
+++ b/src/components/LabelMenuItem.jsx
@@ -1,25 +1,18 @@
 import { useState } from "react";
 
-export function LabelMenuItem({ label, onEdit }) {
-  const [isSelected, setIsSelected] = useState(false);
-
-  const handleToggle = () => {
-    setIsSelected(!isSelected);
-  };
-
+export function LabelMenuItem({ label, isChecked, onToggle, onEdit }) {
   return (
     <div className="label-menu-item">
       <input
         type="checkbox"
         id={`label-${label.id}`}
-        checked={isSelected}
-        onChange={handleToggle}
+        checked={isChecked}
+        onChange={() => onToggle(label.id)}
         className="label-checkbox"
       />
       <label
         htmlFor={`label-${label.id}`}
-        className={`label-color-box ${label.color}`}
-        style={{ backgroundColor: label.color }}
+        className={`label-color-box label-color-option ${label.color}`}
       >
         {label.title && <span className="label-title">{label.title}</span>}
       </label>

--- a/src/components/LabelMenuItem.jsx
+++ b/src/components/LabelMenuItem.jsx
@@ -1,13 +1,13 @@
 import { useState } from "react";
 
-export function LabelMenuItem({ label, isChecked, onToggle, onEdit }) {
+export function LabelMenuItem({ label, isChecked, onToggleLabel, onEdit }) {
   return (
     <div className="label-menu-item">
       <input
         type="checkbox"
         id={`label-${label.id}`}
         checked={isChecked}
-        onChange={() => onToggle(label.id)}
+        onChange={() => onToggleLabel(label.id)}
         className="label-checkbox"
       />
       <label

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -17,8 +17,6 @@ export function List({
   onRemoveList,
   onUpdateList,
   onCopyList,
-  onSaveLabel,
-  onRemoveLabel,
   isAddingCard,
   setActiveAddCardListId,
 }) {

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -18,6 +18,8 @@ export function List({
   boardLabels,
   onRemoveList,
   onUpdateList,
+  onSaveLabel,
+  onRemoveLabel,
   isAddingCard,
   setActiveAddCardListId,
 }) {
@@ -38,9 +40,18 @@ export function List({
     await onRemoveList(list.id);
   }
 
-  async function onUpdateCard(card) {
-    setCards(prev => [...prev, card]);
-    const options = { key: "cards", value: cards };
+  async function onUpdateCard(updatedCard) {
+    const updatedCards = cards.map(card =>
+      card.id === updatedCard.id ? updatedCard : card
+    );
+
+    setCards(updatedCards);
+
+    if (selectedCard && selectedCard.id === updatedCard.id) {
+      setSelectedCard(updatedCard);
+    }
+
+    const options = { key: "cards", value: updatedCards };
     await onUpdateList(list, options);
   }
 
@@ -138,7 +149,6 @@ export function List({
             return (
               <li key={card.id}>
                 <Card
-                  key={card.id}
                   card={card}
                   labels={cardLabels}
                   onClickCard={card => handleOpenModal(card)}
@@ -201,6 +211,9 @@ export function List({
         boardLabels={boardLabels}
         onClose={handleCloseModal}
         isOpen={openModal}
+        onSaveLabel={onSaveLabel}
+        onRemoveLabel={onRemoveLabel}
+        onUpdateCard={onUpdateCard}
       />
     </section>
   );

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -198,6 +198,7 @@ export function List({
         listTitle={list.name}
         cardLabels={getCardLabels(selectedCard)}
         card={selectedCard}
+        boardLabels={boardLabels}
         onClose={handleCloseModal}
         isOpen={openModal}
       />

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -43,19 +43,9 @@ export function List({
     await onRemoveList(list.id);
   }
 
-  async function onUpdateCard(updatedCard) {
-    const updatedCards = cards.map(card =>
-      card.id === updatedCard.id ? updatedCard : card
-    );
-
-    setCards(updatedCards);
-
-    if (selectedCard && selectedCard.id === updatedCard.id) {
-      setSelectedCard(updatedCard);
-    }
-
-    const updates = { cards: updatedCards };
-    await onUpdateList(list, updates);
+  async function onUpdateCard(card) {
+    setCards(prev => [...prev, card]);
+    await onUpdateList(list, { cards });
   }
 
   function handleMoreClick(event) {

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -132,17 +132,11 @@ export function List({
       <div className="list-content-container" ref={listContentRef}>
         <ul className="cards-list">
           {cards.map(card => {
-            const cardLabels =
-              boardLabels && card.labels && card.labels.length > 0
-                ? card.labels
-                    .map(labelId => boardLabels.find(l => l.id === labelId))
-                    .filter(Boolean)
-                : [];
             return (
               <li key={card.id}>
                 <Card
                   card={card}
-                  labels={cardLabels}
+                  labels={getCardLabels(card)}
                   onClickCard={card => handleOpenModal(card)}
                   onRemoveCard={onRemoveCard}
                   onUpdateCard={onUpdateCard}

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -54,8 +54,8 @@ export function List({
       setSelectedCard(updatedCard);
     }
 
-    const options = { key: "cards", value: updatedCards };
-    await onUpdateList(list, options);
+    const updates = { cards: updatedCards };
+    await onUpdateList(list, updates);
   }
 
   function handleMoreClick(event) {

--- a/src/components/Popover.jsx
+++ b/src/components/Popover.jsx
@@ -15,6 +15,7 @@ export function Popover({
   showBack = false,
   onBack,
   paperProps = {},
+  slotProps = {},
   ...popoverProps
 }) {
   return (
@@ -27,6 +28,7 @@ export function Popover({
           className: "popover-paper",
           ...paperProps,
         },
+        ...slotProps,
       }}
       {...popoverProps}
     >

--- a/src/components/Popover.jsx
+++ b/src/components/Popover.jsx
@@ -2,6 +2,7 @@ import PopoverMUI from "@mui/material/Popover";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import { SquareIconButton } from "./ui/buttons/SquareIconButton";
+import ArrowBack from "@mui/icons-material/ArrowBack";
 import Close from "@mui/icons-material/Close";
 
 export function Popover({
@@ -11,6 +12,8 @@ export function Popover({
   title,
   children,
   showClose = true,
+  showBack = false,
+  onBack,
   paperProps = {},
   ...popoverProps
 }) {
@@ -28,6 +31,15 @@ export function Popover({
       {...popoverProps}
     >
       <Box className="popover-header">
+        {showBack && (
+          <Box className="popover-header-back">
+            <SquareIconButton
+              icon={<ArrowBack />}
+              aria-label="Back"
+              onClick={onBack}
+            />
+          </Box>
+        )}
         <Typography className="popover-header-title">{title}</Typography>
         {showClose && (
           <Box className="popover-header-close">

--- a/src/pages/BoardDetails.jsx
+++ b/src/pages/BoardDetails.jsx
@@ -81,21 +81,6 @@ export function BoardDetails() {
     );
   }
 
-  async function onRemoveLabel(labelId) {
-    try {
-      const existingLabels = board.labels || [];
-      const updatedLabels = existingLabels.filter(l => l.id !== labelId);
-      const updates = { labels: updatedLabels };
-      const options = { listId: null, cardId: null };
-
-      await updateBoard(board._id, updates, options);
-      showSuccessMsg("Label removed successfully!");
-    } catch (error) {
-      console.error("Label removal failed:", error);
-      showErrorMsg("Unable to remove label");
-    }
-  }
-
   if (!board) return <div>Loading board...</div>;
 
   return (
@@ -125,13 +110,12 @@ export function BoardDetails() {
               <List
                 key={list.id}
                 list={list}
+                boardLabels={board.labels}
                 labelsIsOpen={labelsIsOpen}
                 setLabelsIsOpen={setLabelsIsOpen}
-                boardLabels={board.labels}
                 onRemoveList={onRemoveList}
                 onUpdateList={onUpdateList}
                 onCopyList={onCopyList}
-                onRemoveLabel={onRemoveLabel}
                 isAddingCard={activeAddCardListId === list.id}
                 setActiveAddCardListId={setActiveAddCardListId}
               />

--- a/src/pages/BoardDetails.jsx
+++ b/src/pages/BoardDetails.jsx
@@ -14,6 +14,7 @@ import { FilterMenu } from "../components/FilterMenu";
 import { showErrorMsg, showSuccessMsg } from "../services/event-bus-service";
 import { getFilteredBoard } from "../services/filter-service";
 import { useCardFilters } from "../hooks/useCardFilters";
+import { LabelMenu } from "../components/LabelMenu";
 
 export function BoardDetails() {
   const params = useParams();
@@ -66,6 +67,7 @@ export function BoardDetails() {
         </div>
       </header>
       <div className="board-canvas">
+        <LabelMenu boardLabels={board.labels} />
         <ul className="lists-list">
           {board.lists.map(list => (
             <li key={list.id}>

--- a/src/pages/BoardDetails.jsx
+++ b/src/pages/BoardDetails.jsx
@@ -67,6 +67,50 @@ export function BoardDetails() {
     );
   }
 
+  async function onSaveLabel(labelData) {
+    try {
+      const existingLabels = board.labels || [];
+      const existingLabelIndex = existingLabels.findIndex(
+        l => l.id === labelData.id
+      );
+
+      let updatedLabels;
+      if (existingLabelIndex >= 0) {
+        updatedLabels = [...existingLabels];
+        updatedLabels[existingLabelIndex] = labelData;
+        showSuccessMsg(`Label "${labelData.title}" updated successfully!`);
+      } else {
+        updatedLabels = [...existingLabels, labelData];
+        showSuccessMsg(`Label "${labelData.title}" created successfully!`);
+      }
+
+      await updateBoard(board, {
+        key: "labels",
+        value: updatedLabels,
+      });
+    } catch (error) {
+      console.error("Label save failed:", error);
+      showErrorMsg(`Unable to save label: ${labelData.title}`);
+    }
+  }
+
+  async function onRemoveLabel(labelId) {
+    try {
+      const existingLabels = board.labels || [];
+      const updatedLabels = existingLabels.filter(l => l.id !== labelId);
+
+      await updateBoard(board, {
+        key: "labels",
+        value: updatedLabels,
+      });
+
+      showSuccessMsg("Label removed successfully!");
+    } catch (error) {
+      console.error("Label removal failed:", error);
+      showErrorMsg("Unable to remove label");
+    }
+  }
+
   if (!board) return <div>Loading board...</div>;
 
   return (
@@ -99,6 +143,8 @@ export function BoardDetails() {
                 boardLabels={board.labels}
                 onRemoveList={onRemoveList}
                 onUpdateList={onUpdateList}
+                onSaveLabel={onSaveLabel}
+                onRemoveLabel={onRemoveLabel}
                 isAddingCard={activeAddCardListId === list.id}
                 setActiveAddCardListId={setActiveAddCardListId}
               />

--- a/src/pages/BoardDetails.jsx
+++ b/src/pages/BoardDetails.jsx
@@ -89,19 +89,21 @@ export function BoardDetails() {
       );
 
       let updatedLabels;
+      let successMsgText;
       if (existingLabelIndex >= 0) {
         updatedLabels = [...existingLabels];
         updatedLabels[existingLabelIndex] = labelData;
-        showSuccessMsg(`Label "${labelData.title}" updated successfully!`);
+        successMsgText = `Label "${labelData.title}" updated successfully!`;
       } else {
         updatedLabels = [...existingLabels, labelData];
-        showSuccessMsg(`Label "${labelData.title}" created successfully!`);
+        successMsgText = `Label "${labelData.title}" created successfully!`;
       }
 
-      await updateBoard(board, {
-        key: "labels",
-        value: updatedLabels,
-      });
+      const updates = { labels: updatedLabels };
+      const options = { listId: null, cardId: null };
+
+      await updateBoard(board._id, updates, options);
+      showSuccessMsg(successMsgText);
     } catch (error) {
       console.error("Label save failed:", error);
       showErrorMsg(`Unable to save label: ${labelData.title}`);
@@ -112,12 +114,10 @@ export function BoardDetails() {
     try {
       const existingLabels = board.labels || [];
       const updatedLabels = existingLabels.filter(l => l.id !== labelId);
+      const updates = { labels: updatedLabels };
+      const options = { listId: null, cardId: null };
 
-      await updateBoard(board, {
-        key: "labels",
-        value: updatedLabels,
-      });
-
+      await updateBoard(board._id, updates, options);
       showSuccessMsg("Label removed successfully!");
     } catch (error) {
       console.error("Label removal failed:", error);

--- a/src/pages/BoardDetails.jsx
+++ b/src/pages/BoardDetails.jsx
@@ -81,35 +81,6 @@ export function BoardDetails() {
     );
   }
 
-  async function onSaveLabel(labelData) {
-    try {
-      const existingLabels = board.labels || [];
-      const existingLabelIndex = existingLabels.findIndex(
-        l => l.id === labelData.id
-      );
-
-      let updatedLabels;
-      let successMsgText;
-      if (existingLabelIndex >= 0) {
-        updatedLabels = [...existingLabels];
-        updatedLabels[existingLabelIndex] = labelData;
-        successMsgText = `Label "${labelData.title}" updated successfully!`;
-      } else {
-        updatedLabels = [...existingLabels, labelData];
-        successMsgText = `Label "${labelData.title}" created successfully!`;
-      }
-
-      const updates = { labels: updatedLabels };
-      const options = { listId: null, cardId: null };
-
-      await updateBoard(board._id, updates, options);
-      showSuccessMsg(successMsgText);
-    } catch (error) {
-      console.error("Label save failed:", error);
-      showErrorMsg(`Unable to save label: ${labelData.title}`);
-    }
-  }
-
   async function onRemoveLabel(labelId) {
     try {
       const existingLabels = board.labels || [];
@@ -160,7 +131,6 @@ export function BoardDetails() {
                 onRemoveList={onRemoveList}
                 onUpdateList={onUpdateList}
                 onCopyList={onCopyList}
-                onSaveLabel={onSaveLabel}
                 onRemoveLabel={onRemoveLabel}
                 isAddingCard={activeAddCardListId === list.id}
                 setActiveAddCardListId={setActiveAddCardListId}

--- a/src/pages/BoardDetails.jsx
+++ b/src/pages/BoardDetails.jsx
@@ -19,7 +19,6 @@ import {
 } from "../services/filter-service";
 import { useCardFilters } from "../hooks/useCardFilters";
 import { SCROLL_DIRECTION, useScrollTo } from "../hooks/useScrollTo";
-import { LabelMenu } from "../components/LabelMenu";
 
 export function BoardDetails() {
   const [activeAddCardListId, setActiveAddCardListId] = useState(null);
@@ -91,7 +90,6 @@ export function BoardDetails() {
         </div>
       </header>
       <div className="board-canvas" ref={boardCanvasRef}>
-        <LabelMenu boardLabels={board.labels} />
         <ul className="lists-list">
           {board.lists.map(list => (
             <li key={list.id}>

--- a/src/pages/CardDetails.jsx
+++ b/src/pages/CardDetails.jsx
@@ -52,7 +52,9 @@ export function CardDetails() {
 
   return (
     <CardModal
-      list={list}
+      boardId={boardId}
+      listId={list.id}
+      listName={list.name}
       card={card}
       cardLabels={cardLabels}
       onEditCard={handleEditCard}

--- a/src/pages/CardDetails.jsx
+++ b/src/pages/CardDetails.jsx
@@ -52,11 +52,11 @@ export function CardDetails() {
 
   return (
     <CardModal
-      cardLabels={cardLabels}
-      listTitle={list.name}
+      list={list}
       card={card}
-      onDeleteCard={handleDeleteCard}
+      cardLabels={cardLabels}
       onEditCard={handleEditCard}
+      onDeleteCard={handleDeleteCard}
       onClose={handleCloseModal}
       isOpen={modalOpen}
     />

--- a/src/pages/CardDetails.jsx
+++ b/src/pages/CardDetails.jsx
@@ -54,7 +54,7 @@ export function CardDetails() {
     <CardModal
       boardId={boardId}
       listId={list.id}
-      listName={list.name}
+      listTitle={list.name}
       card={card}
       cardLabels={cardLabels}
       onEditCard={handleEditCard}

--- a/src/services/board/board-service-local.js
+++ b/src/services/board/board-service-local.js
@@ -21,6 +21,10 @@ export const boardService = {
   deleteCard,
   getEmptyList,
   copyList,
+  createLabel,
+  editLabel,
+  deleteLabel,
+  updateCardLabels,
 };
 window.bs = boardService;
 
@@ -365,6 +369,69 @@ function updateCardFields(board, listId, cardId, updates) {
   );
   const updatedList = { ...list, cards: updatedCards };
   return updateListFields(board, listId, updatedList);
+}
+
+async function createLabel(boardId, label) {
+  try {
+    const board = await getById(boardId);
+    if (!board) throw new Error("Board not found");
+
+    await updateBoard(boardId, { labels: [...board.labels, label] });
+  } catch (error) {
+    console.error("Cannot create label:", error);
+    throw error;
+  }
+}
+
+async function editLabel(boardId, label) {
+  try {
+    const board = await getById(boardId);
+    if (!board) throw new Error("Board not found");
+
+    const updatedLabels = board.labels.map(l =>
+      l.id === label.id ? label : l
+    );
+
+    await updateBoard(boardId, { labels: updatedLabels });
+  } catch (error) {
+    console.error("Cannot edit label:", error);
+    throw error;
+  }
+}
+
+async function deleteLabel(boardId, labelId) {
+  try {
+    const board = await getById(boardId);
+    if (!board) throw new Error("Board not found");
+
+    const updatedLabels = board.labels.filter(l => l.id !== labelId);
+
+    await updateBoard(boardId, { labels: updatedLabels });
+  } catch (error) {
+    console.error("Cannot delete label:", error);
+    throw error;
+  }
+}
+
+async function updateCardLabels(boardId, listId, cardId, updatedCardLabels) {
+  try {
+    const board = await getById(boardId);
+    if (!board) throw new Error("Board not found");
+
+    const updatedBoard = await updateBoard(
+      boardId,
+      { labels: updatedCardLabels },
+      {
+        listId,
+        cardId,
+      }
+    );
+
+    return updatedCardLabels;
+  } catch (error) {
+    console.error("Cannot update card labels:", error);
+    throw error;
+  }
 }
 
 /* _applyBoardUpdate removed: logic now handled directly in updateBoard */

--- a/src/services/board/board-service-local.js
+++ b/src/services/board/board-service-local.js
@@ -1,5 +1,5 @@
 import { storageService } from "../async-storage-service";
-import { loadFromStorage, makeId, saveToStorage } from "../util-service";
+import { loadFromStorage, saveToStorage } from "../util-service";
 import boardDataGenerator from "./board-data-generator";
 import { USER_STORAGE_KEY } from "../user/user-service-local.js";
 import { getFilteredBoard } from "../filter-service";
@@ -160,7 +160,7 @@ function _createActivity(
   cardId = null
 ) {
   return {
-    id: makeId(),
+    id: crypto.randomUUID(),
     type: "activity",
     createdAt: Date.now(),
     board: boardId,

--- a/src/services/board/index.js
+++ b/src/services/board/index.js
@@ -1,12 +1,11 @@
 const { DEV, VITE_LOCAL } = import.meta.env;
 
-import { makeId } from "../util-service.js";
 import { boardService as local } from "./board-service-local";
 import boardDataGenerator from "../board/board-data-generator.js";
 
 function getEmptyBoard() {
   return {
-    _id: "",
+    _id: crypto.randomUUID(),
     name: "",
     description: "",
     createdAt: "",
@@ -19,7 +18,7 @@ function getEmptyBoard() {
 
 function getEmptyCard() {
   return {
-    id: makeId(),
+    id: crypto.randomUUID(),
     title: "",
     description: "",
     labels: [],
@@ -27,8 +26,21 @@ function getEmptyCard() {
   };
 }
 
+export function getEmptyLabel() {
+  return {
+    id: crypto.randomUUID(),
+    title: "",
+    color: "",
+  };
+}
+
 const service = VITE_LOCAL === "true" ? local : local; // "true" ? local : remote;
-export const boardService = { getEmptyBoard, getEmptyCard, ...service };
+export const boardService = {
+  getEmptyBoard,
+  getEmptyCard,
+  getEmptyLabel,
+  ...service,
+};
 
 // Easy access to this service from the dev tools console
 // when using script - dev / dev:local

--- a/src/store/actions/board-actions.js
+++ b/src/store/actions/board-actions.js
@@ -119,24 +119,6 @@ export async function deleteCard(boardId, cardId, listId) {
   }
 }
 
-export async function addNewLabelToCard(
-  boardId,
-  boardUpdates,
-  boardOptions,
-  card,
-  listId
-) {
-  try {
-    await updateBoard(boardId, boardUpdates, boardOptions);
-    await editCard(boardId, card, listId);
-  } catch (error) {
-    store.dispatch(
-      setError(`Error adding new label to card: ${error.message}`)
-    );
-    throw error;
-  }
-}
-
 export function addCardAction(card, listId) {
   return { type: ADD_CARD, payload: { card, listId } };
 }

--- a/src/store/actions/board-actions.js
+++ b/src/store/actions/board-actions.js
@@ -212,30 +212,33 @@ export async function moveList(
 
 export async function createLabel(boardId, label) {
   try {
+    store.dispatch({ type: CREATE_LABEL.REQUEST });
     await boardService.createLabel(boardId, label);
-    store.dispatch(createLabelAction(label));
+    store.dispatch({ type: CREATE_LABEL.SUCCESS, payload: label });
   } catch (error) {
-    store.dispatch(setError(`Error creating label: ${error.message}`));
+    store.dispatch({ type: CREATE_LABEL.FAILURE, payload: error.message });
     throw error;
   }
 }
 
 export async function editLabel(boardId, label) {
   try {
+    store.dispatch({ type: EDIT_LABEL.REQUEST });
     await boardService.editLabel(boardId, label);
-    store.dispatch(editLabelAction(label));
+    store.dispatch({ type: EDIT_LABEL.SUCCESS, payload: label });
   } catch (error) {
-    store.dispatch(setError(`Error editing label: ${error.message}`));
+    store.dispatch({ type: EDIT_LABEL.FAILURE, payload: error.message });
     throw error;
   }
 }
 
 export async function deleteLabel(boardId, labelId) {
   try {
+    store.dispatch({ type: DELETE_LABEL.REQUEST });
     await boardService.deleteLabel(boardId, labelId);
-    store.dispatch(deleteLabelAction(labelId));
+    store.dispatch({ type: DELETE_LABEL.SUCCESS, payload: labelId });
   } catch (error) {
-    store.dispatch(setError(`Error deleting label: ${error.message}`));
+    store.dispatch({ type: DELETE_LABEL.FAILURE, payload: error.message });
     throw error;
   }
 }
@@ -247,36 +250,24 @@ export async function updateCardLabels(
   updatedCardLabels
 ) {
   try {
+    store.dispatch({ type: UPDATE_CARD_LABELS.REQUEST });
     await boardService.updateCardLabels(
       boardId,
       listId,
       cardId,
       updatedCardLabels
     );
-    store.dispatch(updateCardLabelsAction(listId, cardId, updatedCardLabels));
+    store.dispatch({
+      type: UPDATE_CARD_LABELS.SUCCESS,
+      payload: { listId, cardId, updatedCardLabels },
+    });
   } catch (error) {
-    store.dispatch(setError(`Error updating card labels: ${error.message}`));
+    store.dispatch({
+      type: UPDATE_CARD_LABELS.FAILURE,
+      payload: error.message,
+    });
     throw error;
   }
-}
-
-export function createLabelAction(label) {
-  return { type: CREATE_LABEL, payload: label };
-}
-
-export function editLabelAction(label) {
-  return { type: EDIT_LABEL, payload: label };
-}
-
-export function deleteLabelAction(labelId) {
-  return { type: DELETE_LABEL, payload: labelId };
-}
-
-export function updateCardLabelsAction(listId, cardId, updatedCardLabels) {
-  return {
-    type: UPDATE_CARD_LABELS,
-    payload: { listId, cardId, updatedCardLabels },
-  };
 }
 
 export function setBoards(boards) {

--- a/src/store/actions/board-actions.js
+++ b/src/store/actions/board-actions.js
@@ -11,7 +11,6 @@ import {
   ADD_CARD,
   EDIT_CARD,
   DELETE_CARD,
-  ADD_BOARD_LABEL,
 } from "../reducers/board-reducer";
 
 import { store } from "../store";
@@ -120,7 +119,7 @@ export async function deleteCard(boardId, cardId, listId) {
   }
 }
 
-export async function addLabel(
+export async function addNewLabelToCard(
   boardId,
   boardUpdates,
   boardOptions,
@@ -131,13 +130,11 @@ export async function addLabel(
     await updateBoard(boardId, boardUpdates, boardOptions);
     await editCard(boardId, card, listId);
   } catch (error) {
-    store.dispatch(setError(`Error adding label: ${error.message}`));
+    store.dispatch(
+      setError(`Error adding new label to card: ${error.message}`)
+    );
     throw error;
   }
-}
-
-export function addBoardLabelAction(label) {
-  return { type: ADD_BOARD_LABEL, payload: label };
 }
 
 export function addCardAction(card, listId) {

--- a/src/store/actions/board-actions.js
+++ b/src/store/actions/board-actions.js
@@ -11,6 +11,7 @@ import {
   ADD_CARD,
   EDIT_CARD,
   DELETE_CARD,
+  ADD_BOARD_LABEL,
 } from "../reducers/board-reducer";
 
 import { store } from "../store";
@@ -119,8 +120,24 @@ export async function deleteCard(boardId, cardId, listId) {
   }
 }
 
-export function deleteCardAction(cardId, listId) {
-  return { type: DELETE_CARD, payload: { cardId, listId } };
+export async function addLabel(
+  boardId,
+  boardUpdates,
+  boardOptions,
+  card,
+  listId
+) {
+  try {
+    await updateBoard(boardId, boardUpdates, boardOptions);
+    await editCard(boardId, card, listId);
+  } catch (error) {
+    store.dispatch(setError(`Error adding label: ${error.message}`));
+    throw error;
+  }
+}
+
+export function addBoardLabelAction(label) {
+  return { type: ADD_BOARD_LABEL, payload: label };
 }
 
 export function addCardAction(card, listId) {
@@ -129,6 +146,10 @@ export function addCardAction(card, listId) {
 
 export function editCardAction(card, listId) {
   return { type: EDIT_CARD, payload: { card, listId } };
+}
+
+export function deleteCardAction(cardId, listId) {
+  return { type: DELETE_CARD, payload: { cardId, listId } };
 }
 
 export function setBoards(boards) {

--- a/src/store/actions/board-actions.js
+++ b/src/store/actions/board-actions.js
@@ -12,6 +12,10 @@ import {
   ADD_CARD,
   EDIT_CARD,
   DELETE_CARD,
+  CREATE_LABEL,
+  EDIT_LABEL,
+  DELETE_LABEL,
+  UPDATE_CARD_LABELS,
 } from "../reducers/board-reducer";
 
 import { store } from "../store";
@@ -153,6 +157,75 @@ export async function moveList(
     store.dispatch(setError(`Error moving list: ${error.message}`));
     throw error;
   }
+}
+
+export async function createLabel(boardId, label) {
+  try {
+    await boardService.createLabel(boardId, label);
+    store.dispatch(createLabelAction(label));
+  } catch (error) {
+    store.dispatch(setError(`Error creating label: ${error.message}`));
+    throw error;
+  }
+}
+
+export async function editLabel(boardId, label) {
+  try {
+    await boardService.editLabel(boardId, label);
+    store.dispatch(editLabelAction(label));
+  } catch (error) {
+    store.dispatch(setError(`Error editing label: ${error.message}`));
+    throw error;
+  }
+}
+
+export async function deleteLabel(boardId, labelId) {
+  try {
+    await boardService.deleteLabel(boardId, labelId);
+    store.dispatch(deleteLabelAction(labelId));
+  } catch (error) {
+    store.dispatch(setError(`Error deleting label: ${error.message}`));
+    throw error;
+  }
+}
+
+export async function updateCardLabels(
+  boardId,
+  listId,
+  cardId,
+  updatedCardLabels
+) {
+  try {
+    await boardService.updateCardLabels(
+      boardId,
+      listId,
+      cardId,
+      updatedCardLabels
+    );
+    store.dispatch(updateCardLabelsAction(listId, cardId, updatedCardLabels));
+  } catch (error) {
+    store.dispatch(setError(`Error updating card labels: ${error.message}`));
+    throw error;
+  }
+}
+
+export function createLabelAction(label) {
+  return { type: CREATE_LABEL, payload: label };
+}
+
+export function editLabelAction(label) {
+  return { type: EDIT_LABEL, payload: label };
+}
+
+export function deleteLabelAction(labelId) {
+  return { type: DELETE_LABEL, payload: labelId };
+}
+
+export function updateCardLabelsAction(listId, cardId, updatedCardLabels) {
+  return {
+    type: UPDATE_CARD_LABELS,
+    payload: { listId, cardId, updatedCardLabels },
+  };
 }
 
 export function setBoards(boards) {

--- a/src/store/reducers/board-reducer.js
+++ b/src/store/reducers/board-reducer.js
@@ -119,6 +119,50 @@ const handlers = {
       ),
     },
   }),
+  [CREATE_LABEL]: (state, action) => ({
+    ...state,
+    board: {
+      ...state.board,
+      labels: [...state.board.labels, action.payload],
+    },
+  }),
+  [EDIT_LABEL]: (state, action) => ({
+    ...state,
+    board: {
+      ...state.board,
+      labels: state.board.labels.map(l =>
+        l.id === action.payload.id ? action.payload : l
+      ),
+    },
+  }),
+  [DELETE_LABEL]: (state, action) => ({
+    ...state,
+    board: {
+      ...state.board,
+      labels: state.board.labels.filter(l => l.id !== action.payload),
+    },
+  }),
+  [UPDATE_CARD_LABELS]: (state, action) => ({
+    ...state,
+    board: {
+      ...state.board,
+      lists: state.board.lists.map(list =>
+        list.id === action.payload.listId
+          ? {
+              ...list,
+              cards: list.cards.map(card =>
+                card.id === action.payload.cardId
+                  ? {
+                      ...card,
+                      labels: action.payload.updatedCardLabels,
+                    }
+                  : card
+              ),
+            }
+          : list
+      ),
+    },
+  }),
   [SET_LOADING]: (state, action) => ({
     ...state,
     loading: {

--- a/src/store/reducers/board-reducer.js
+++ b/src/store/reducers/board-reducer.js
@@ -8,7 +8,6 @@ export const UPDATE_BOARD = "UPDATE_BOARD";
 export const ADD_CARD = "ADD_CARD";
 export const EDIT_CARD = "EDIT_CARD";
 export const DELETE_CARD = "DELETE_CARD";
-export const ADD_BOARD_LABEL = "ADD_BOARD_LABEL";
 export const SET_LOADING = "boards/SET_LOADING";
 export const SET_ERROR = "boards/SET_ERROR";
 export const SET_FILTERS = "boards/SET_FILTERS";
@@ -81,14 +80,6 @@ export function boardReducer(state = initialState, action) {
                 }
               : list
           ),
-        },
-      };
-    case ADD_BOARD_LABEL:
-      return {
-        ...state,
-        board: {
-          ...state.board,
-          labels: [...state.board.labels, action.payload],
         },
       };
     case SET_LOADING:

--- a/src/store/reducers/board-reducer.js
+++ b/src/store/reducers/board-reducer.js
@@ -12,10 +12,10 @@ export const ADD_CARD = "ADD_CARD";
 export const EDIT_CARD = "EDIT_CARD";
 export const DELETE_CARD = "DELETE_CARD";
 export const MOVE_LIST = "MOVE_LIST";
-export const CREATE_LABEL = "CREATE_LABEL";
-export const EDIT_LABEL = "EDIT_LABEL";
-export const DELETE_LABEL = "DELETE_LABEL";
-export const UPDATE_CARD_LABELS = "UPDATE_CARD_LABELS";
+export const CREATE_LABEL = createAsyncActionTypes("CREATE_LABEL");
+export const EDIT_LABEL = createAsyncActionTypes("EDIT_LABEL");
+export const DELETE_LABEL = createAsyncActionTypes("DELETE_LABEL");
+export const UPDATE_CARD_LABELS = createAsyncActionTypes("UPDATE_CARD_LABELS");
 
 export const SET_LOADING = "boards/SET_LOADING";
 export const SET_ERROR = "boards/SET_ERROR";

--- a/src/store/reducers/board-reducer.js
+++ b/src/store/reducers/board-reducer.js
@@ -8,6 +8,7 @@ export const UPDATE_BOARD = "UPDATE_BOARD";
 export const ADD_CARD = "ADD_CARD";
 export const EDIT_CARD = "EDIT_CARD";
 export const DELETE_CARD = "DELETE_CARD";
+export const ADD_BOARD_LABEL = "ADD_BOARD_LABEL";
 export const SET_LOADING = "boards/SET_LOADING";
 export const SET_ERROR = "boards/SET_ERROR";
 export const SET_FILTERS = "boards/SET_FILTERS";
@@ -80,6 +81,14 @@ export function boardReducer(state = initialState, action) {
                 }
               : list
           ),
+        },
+      };
+    case ADD_BOARD_LABEL:
+      return {
+        ...state,
+        board: {
+          ...state.board,
+          labels: [...state.board.labels, action.payload],
         },
       };
     case SET_LOADING:

--- a/src/store/reducers/board-reducer.js
+++ b/src/store/reducers/board-reducer.js
@@ -9,6 +9,11 @@ export const ADD_CARD = "ADD_CARD";
 export const EDIT_CARD = "EDIT_CARD";
 export const DELETE_CARD = "DELETE_CARD";
 export const MOVE_LIST = "MOVE_LIST";
+export const CREATE_LABEL = "CREATE_LABEL";
+export const EDIT_LABEL = "EDIT_LABEL";
+export const DELETE_LABEL = "DELETE_LABEL";
+export const UPDATE_CARD_LABELS = "UPDATE_CARD_LABELS";
+
 export const SET_LOADING = "boards/SET_LOADING";
 export const SET_ERROR = "boards/SET_ERROR";
 export const SET_FILTERS = "boards/SET_FILTERS";
@@ -85,6 +90,54 @@ export function boardReducer(state = initialState, action) {
                   ...list,
                   cards: list.cards.filter(
                     card => card.id !== action.payload.cardId
+                  ),
+                }
+              : list
+          ),
+        },
+      };
+    case CREATE_LABEL:
+      return {
+        ...state,
+        board: {
+          ...state.board,
+          labels: [...state.board.labels, action.payload],
+        },
+      };
+    case EDIT_LABEL:
+      return {
+        ...state,
+        board: {
+          ...state.board,
+          labels: state.board.labels.map(l =>
+            l.id === action.payload.id ? action.payload : l
+          ),
+        },
+      };
+    case DELETE_LABEL:
+      return {
+        ...state,
+        board: {
+          ...state.board,
+          labels: state.board.labels.filter(l => l.id !== action.payload),
+        },
+      };
+    case UPDATE_CARD_LABELS:
+      return {
+        ...state,
+        board: {
+          ...state.board,
+          lists: state.board.lists.map(list =>
+            list.id === action.payload.listId
+              ? {
+                  ...list,
+                  cards: list.cards.map(card =>
+                    card.id === action.payload.cardId
+                      ? {
+                          ...card,
+                          labels: action.payload.updatedCardLabels,
+                        }
+                      : card
                   ),
                 }
               : list


### PR DESCRIPTION
## 🎯 Description
Implemented a comprehensive label management system that allows users to create, edit, delete, and assign labels to cards. The feature includes a searchable label menu with real-time filtering and a visual label editor with color previews.

## 🔧 Changes
- **LabelMenu Component**: Main menu displaying all board labels with search functionality and label assignment checkboxes
- **LabelEditor Component**: Create/edit label interface with live color preview and 10 predefined color options
- **LabelMenuItem Component**: Individual label item with checkbox for card assignment and edit button
- **Label CRUD Operations**: Full create, read, update, delete functionality integrated with board state management
- **Card Label Assignment**: Toggle labels on/off for cards directly from the label menu
- **CSS Variables**: Defined label color scheme (bg, border, text) for 10 colors in `var.css`
- **Search & Filter**: Real-time label search with case-insensitive filtering

## 📝 Technical Notes
- Labels stored at board level; cards reference labels by ID
- New labels automatically assigned to current card upon creation
- Back navigation in list view closes menu; in editor view returns to list
- State properly resets when menu opens/closes to prevent stale data
- Fixed duplicate key warnings and card update logic to prevent duplicates

## 🎨 UI/UX Highlights
- Smooth view transitions between list and editor
- Live preview updates as user types label title
- Visual feedback for selected labels with checkboxes
- Responsive color grid with hover effects and selection indicators