### PR TITLE
feature/CATC_54-implement-copy-list-in-list-actions

### DIFF
--- a/src/assets/styles/components/CopyListForm.css
+++ b/src/assets/styles/components/CopyListForm.css
@@ -1,0 +1,17 @@
+.copy-list-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px;
+}
+
+.copy-list-form textarea {
+  width: 100%;
+  background-color: #242528;
+  border-radius: 0.25rem;
+  border: none;
+  outline: none;
+  .MuiInputBase-input {
+    color: #bfc1c4;
+  }
+}

--- a/src/assets/styles/main.css
+++ b/src/assets/styles/main.css
@@ -28,6 +28,7 @@
 @import "components/Board";
 @import "components/List";
 @import "components/ListActionsMenu";
+@import "components/CopyListForm";
 @import "components/Card";
 @import "components/FilterMenu";
 

--- a/src/assets/styles/setup/var.css
+++ b/src/assets/styles/setup/var.css
@@ -78,4 +78,11 @@
   --icon-btn-color-hover: #bfc1c4;
   --icon-btn-color-active: #1f1f21;
   --icon-btn-color-active-hover: #1f1f21;
+
+  --action-btn-bg-default: #669df1;
+  --action-btn-bg-hover: #8fb8f6;
+  --action-btn-bg-active: #cfe1fd;
+  --action-btn-color-default: #1f1f21;
+  --action-btn-color-hover: var(--action-btn-color-default);
+  --action-btn-color-active: var(--action-btn-color-default);
 }

--- a/src/components/CopyListForm.jsx
+++ b/src/components/CopyListForm.jsx
@@ -17,8 +17,9 @@ export default function CopyListForm({ initialValue, onCopy, onCancel }) {
 
   function handleSubmit(e) {
     e.preventDefault();
-    if (onCopy && textareaValue.trim()) {
-      onCopy(textareaValue.trim());
+    const newName = textareaValue.trim();
+    if (newName) {
+      onCopy(newName);
     }
     setTextareaValue("");
   }
@@ -45,7 +46,7 @@ export default function CopyListForm({ initialValue, onCopy, onCancel }) {
         className="copy-list-textfield"
         ref={textareaRef}
         value={textareaValue}
-        onChange={e => setTextareaValue(e.target.value)}
+        onChange={e => setTextareaValue(e.target.value.trim())}
         onKeyDown={handleKeyDown}
         minRows={2}
         autoFocus

--- a/src/components/CopyListForm.jsx
+++ b/src/components/CopyListForm.jsx
@@ -5,7 +5,7 @@ import Button from "@mui/material/Button";
 import Box from "@mui/material/Box";
 import ActionButton from "./ui/buttons/ActionButton";
 
-export default function CopyListForm({ initialValue, onCopy, onCancel }) {
+export default function CopyListForm({ initialValue, onSubmit, onCancel }) {
   const textareaRef = useRef(null);
   const [textareaValue, setTextareaValue] = useState(initialValue || "");
 
@@ -18,9 +18,9 @@ export default function CopyListForm({ initialValue, onCopy, onCancel }) {
   function handleSubmit(e) {
     e.preventDefault();
     const newName = textareaValue.trim();
-    if (newName) {
-      onCopy(newName);
-    }
+    if (!newName) return;
+
+    onSubmit(newName);
     setTextareaValue("");
   }
 

--- a/src/components/CopyListForm.jsx
+++ b/src/components/CopyListForm.jsx
@@ -46,7 +46,7 @@ export default function CopyListForm({ initialValue, onCopy, onCancel }) {
         className="copy-list-textfield"
         ref={textareaRef}
         value={textareaValue}
-        onChange={e => setTextareaValue(e.target.value.trim())}
+        onChange={e => setTextareaValue(e.target.value)}
         onKeyDown={handleKeyDown}
         minRows={2}
         autoFocus

--- a/src/components/CopyListForm.jsx
+++ b/src/components/CopyListForm.jsx
@@ -1,0 +1,73 @@
+import { useState, useRef, useEffect } from "react";
+
+import TextareaAutosize from "@mui/material/TextareaAutosize";
+import Button from "@mui/material/Button";
+import Box from "@mui/material/Box";
+import ActionButton from "./ui/buttons/ActionButton";
+
+export default function CopyListForm({ initialValue, onCopy, onCancel }) {
+  const textareaRef = useRef(null);
+  const [textareaValue, setTextareaValue] = useState(initialValue || "");
+
+  useEffect(() => {
+    if (textareaRef.current) {
+      textareaRef.current.focus();
+    }
+  }, []);
+
+  function handleSubmit(e) {
+    e.preventDefault();
+    if (onCopy && textareaValue.trim()) {
+      onCopy(textareaValue.trim());
+    }
+    setTextareaValue("");
+  }
+
+  function handleKeyDown(e) {
+    if (e.key === "Escape") {
+      if (onCancel) onCancel();
+      setTextareaValue(initialValue);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="copy-list-form">
+      <Box mb={1}>
+        <label
+          htmlFor="copy-list-textfield"
+          style={{ fontWeight: 500, fontSize: 15 }}
+        >
+          Name
+        </label>
+      </Box>
+      <TextareaAutosize
+        id="copy-list-textfield"
+        className="copy-list-textfield"
+        ref={textareaRef}
+        value={textareaValue}
+        onChange={e => setTextareaValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        minRows={2}
+        autoFocus
+      />
+      <Box display="flex" gap={1}>
+        <ActionButton
+          type="submit"
+          variant="contained"
+          size="small"
+          disabled={!textareaValue.trim()}
+        >
+          Create list
+        </ActionButton>
+        <Button
+          type="button"
+          variant="contained"
+          size="small"
+          onClick={onCancel}
+        >
+          Back
+        </Button>
+      </Box>
+    </form>
+  );
+}

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -22,6 +22,7 @@ export function List({
   onUpdateList,
   isAddingCard,
   setActiveAddCardListId,
+  onCopyList,
 }) {
   const [cards, setCards] = useState(list.cards);
   const [anchorEl, setAnchorEl] = useState(null);
@@ -195,7 +196,7 @@ export function List({
         onClose={handleClose}
         onEditList={handleEditList}
         onDeleteList={handleDeleteList}
-        onCopyList={n => console.log(n)}
+        onCopyList={onCopyList}
       />
 
       {/* Card Modal will be moved out of here */}

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -189,11 +189,13 @@ export function List({
       </div>
 
       <ListActionsMenu
+        list={list}
         anchorEl={anchorEl}
         isOpen={open}
         onClose={handleClose}
         onEditList={handleEditList}
         onDeleteList={handleDeleteList}
+        onCopyList={n => console.log(n)}
       />
 
       {/* Card Modal will be moved out of here */}

--- a/src/components/ListActionsMenu.jsx
+++ b/src/components/ListActionsMenu.jsx
@@ -52,7 +52,7 @@ export function ListActionsMenu({
       {activeAction === "copy" ? (
         <CopyListForm
           initialValue={list.name}
-          onCopy={newName => handleCopyList(list.id, newName)}
+          onSubmit={newName => handleCopyList(list.id, newName)}
           onCancel={handleCopyCancel}
         />
       ) : (

--- a/src/components/ListActionsMenu.jsx
+++ b/src/components/ListActionsMenu.jsx
@@ -1,29 +1,48 @@
 import MenuList from "@mui/material/MenuList";
 import MenuItem from "@mui/material/MenuItem";
 import ListItemText from "@mui/material/ListItemText";
+import { useState } from "react";
 import { Popover } from "./Popover";
+import CopyListForm from "./CopyListForm";
 import "../assets/styles/components/ListActionsMenu.css";
 
-function listActionsMenuItems() {
-  return [
-    { label: "Add Card", action: () => {} },
-    { label: "Copy List", action: () => {} },
-    { label: "Move List", action: () => {} },
-    { label: "Move All cards in this list", action: () => {} },
-    { label: "Sort list...", action: () => {} },
-    { label: "Watch", action: () => {} },
-    { label: "Archive this list", action: () => {} },
-    { label: "Archive all cards in this list", action: () => {} },
-  ];
-}
+export function ListActionsMenu({
+  list,
+  anchorEl,
+  isOpen,
+  onClose,
+  onCopyList,
+}) {
+  const [activeAction, setActiveAction] = useState(null);
 
-export function ListActionsMenu({ anchorEl, isOpen, onClose }) {
+  function handleMenuClick(key) {
+    if (key === "copy") {
+      setActiveAction("copy");
+    }
+  }
+
+  function handleCopyList(newName) {
+    if (onCopyList && newName) {
+      onCopyList(newName);
+    }
+    setActiveAction(null);
+  }
+
+  function handleCopyCancel() {
+    setActiveAction(null);
+  }
+
+  function onPopoverClose() {
+    setActiveAction(null);
+    onClose();
+  }
+
   return (
     <Popover
       className="list-actions-menu-popover"
       anchorEl={anchorEl}
       open={isOpen}
-      onClose={onClose}
+      onClose={onPopoverClose}
       title="List actions"
       anchorOrigin={{
         vertical: "bottom",
@@ -31,13 +50,35 @@ export function ListActionsMenu({ anchorEl, isOpen, onClose }) {
       }}
       paperProps={{ sx: { mt: 1 } }}
     >
-      <MenuList className="list-actions-menu" dense>
-        {listActionsMenuItems().map(({ label, action }) => (
-          <MenuItem key={label} onClick={action}>
-            <ListItemText>{label}</ListItemText>
-          </MenuItem>
-        ))}
-      </MenuList>
+      {activeAction === "copy" ? (
+        <CopyListForm
+          list={list}
+          initialValue={list.name}
+          onCopy={handleCopyList}
+          onCancel={handleCopyCancel}
+        />
+      ) : (
+        <MenuList className="list-actions-menu" dense>
+          {listActionsMenuItems().map(({ label, key }) => (
+            <MenuItem key={key} onClick={() => handleMenuClick(key)}>
+              <ListItemText>{label}</ListItemText>
+            </MenuItem>
+          ))}
+        </MenuList>
+      )}
     </Popover>
   );
+}
+
+function listActionsMenuItems() {
+  return [
+    { label: "Add Card", key: "add" },
+    { label: "Copy List", key: "copy" },
+    { label: "Move List", key: "move" },
+    { label: "Move All cards in this list", key: "moveAll" },
+    { label: "Sort list...", key: "sort" },
+    { label: "Watch", key: "watch" },
+    { label: "Archive this list", key: "archive" },
+    { label: "Archive all cards in this list", key: "archiveAll" },
+  ];
 }

--- a/src/components/ListActionsMenu.jsx
+++ b/src/components/ListActionsMenu.jsx
@@ -21,11 +21,10 @@ export function ListActionsMenu({
     }
   }
 
-  function handleCopyList(newName) {
-    if (onCopyList && newName) {
-      onCopyList(newName);
-    }
+  function handleCopyList(listId, newName) {
+    onCopyList(listId, newName);
     setActiveAction(null);
+    onClose();
   }
 
   function handleCopyCancel() {
@@ -52,9 +51,8 @@ export function ListActionsMenu({
     >
       {activeAction === "copy" ? (
         <CopyListForm
-          list={list}
           initialValue={list.name}
-          onCopy={handleCopyList}
+          onCopy={newName => handleCopyList(list.id, newName)}
           onCancel={handleCopyCancel}
         />
       ) : (

--- a/src/components/ui/buttons/ActionButton.jsx
+++ b/src/components/ui/buttons/ActionButton.jsx
@@ -1,0 +1,37 @@
+import Button from "@mui/material/Button";
+
+export default function ActionButton({
+  sx = {},
+  selected,
+  children,
+  ...props
+}) {
+  return (
+    <Button
+      size="small"
+      variant="contained"
+      sx={{
+        fontWeight: "bold",
+        textDecoration: "none",
+        color: selected
+          ? "var(--action-btn-color-active)"
+          : "var(--action-btn-color-default)",
+        backgroundColor: selected
+          ? "var(--action-btn-bg-active)"
+          : "var(--action-btn-bg-default)",
+        "&:hover": {
+          backgroundColor: selected
+            ? "var(--action-btn-bg-active)"
+            : "var(--action-btn-bg-hover)",
+          color: selected
+            ? "var(--action-btn-color-active)"
+            : "var(--action-btn-color-hover)",
+        },
+        ...sx,
+      }}
+      {...props}
+    >
+      {children}
+    </Button>
+  );
+}

--- a/src/pages/BoardDetails.jsx
+++ b/src/pages/BoardDetails.jsx
@@ -7,7 +7,11 @@ import Sort from "@mui/icons-material/Sort";
 import StarBorderRounded from "@mui/icons-material/StarBorderRounded";
 import LockOutlineRounded from "@mui/icons-material/LockOutlineRounded";
 
-import { loadBoard, updateBoard } from "../store/actions/board-actions";
+import {
+  loadBoard,
+  updateBoard,
+  copyList,
+} from "../store/actions/board-actions";
 import { Footer } from "../components/Footer";
 import { List } from "../components/List";
 import { AddList } from "../components/AddList";
@@ -46,15 +50,8 @@ export function BoardDetails() {
 
   async function onCopyList(listId, newName) {
     try {
-      const updatedLists = await boardService.copyList(
-        board._id,
-        listId,
-        newName
-      );
-      updateBoard(board._id, {
-        key: "lists",
-        value: updatedLists,
-      });
+      await copyList(board._id, listId, newName);
+      showSuccessMsg(`The list copied successfully!`);
     } catch (error) {
       console.error("List copy failed:", error);
       showErrorMsg(`Unable to copy the list: ${listId}`);

--- a/src/pages/BoardDetails.jsx
+++ b/src/pages/BoardDetails.jsx
@@ -44,10 +44,14 @@ export function BoardDetails() {
     setSearchParams(filterBy);
   }, [filters, setSearchParams]);
 
-  function onCopyList(listId, newName) {
+  async function onCopyList(listId, newName) {
     try {
-      const updatedLists = boardService.copyList(board, listId, newName);
-      updateBoard(board, {
+      const updatedLists = await boardService.copyList(
+        board._id,
+        listId,
+        newName
+      );
+      updateBoard(board._id, {
         key: "lists",
         value: updatedLists,
       });
@@ -62,7 +66,7 @@ export function BoardDetails() {
   async function onUpdateList(list, { cardId = null, key, value }) {
     try {
       const options = { listId: list.id, cardId, key, value };
-      updateBoard(board, options);
+      updateBoard(board._id, options);
       showSuccessMsg(`The list ${list.name} updated successfully!`);
     } catch (error) {
       console.error("List update failed:", error);
@@ -71,7 +75,7 @@ export function BoardDetails() {
   }
 
   async function onAddList(newList) {
-    await updateBoard(board, {
+    await updateBoard(board._id, {
       key: "lists",
       value: [...board.lists, newList],
     });

--- a/src/pages/BoardDetails.jsx
+++ b/src/pages/BoardDetails.jsx
@@ -44,6 +44,19 @@ export function BoardDetails() {
     setSearchParams(filterBy);
   }, [filters, setSearchParams]);
 
+  function onCopyList(listId, newName) {
+    try {
+      const updatedLists = boardService.copyList(board, listId, newName);
+      updateBoard(board, {
+        key: "lists",
+        value: updatedLists,
+      });
+    } catch (error) {
+      console.error("List copy failed:", error);
+      showErrorMsg(`Unable to copy the list: ${listId}`);
+    }
+  }
+
   async function onRemoveList(listId) {}
 
   async function onUpdateList(list, { cardId = null, key, value }) {
@@ -102,6 +115,7 @@ export function BoardDetails() {
                 boardLabels={board.labels}
                 onRemoveList={onRemoveList}
                 onUpdateList={onUpdateList}
+                onCopyList={onCopyList}
                 isAddingCard={activeAddCardListId === list.id}
                 setActiveAddCardListId={setActiveAddCardListId}
               />

--- a/src/services/board/board-service-local.js
+++ b/src/services/board/board-service-local.js
@@ -16,6 +16,7 @@ export const boardService = {
   clearData,
   reCreateBoards,
   getEmptyList,
+  copyList,
 };
 window.bs = boardService;
 
@@ -27,6 +28,34 @@ async function query() {
 
     throw error;
   }
+}
+
+export function copyList(board, listId, newName) {
+  const originalListIndex = board.lists.findIndex(l => l.id === listId);
+  if (originalListIndex === -1) throw new Error("List not found");
+
+  const listToCopy = board.lists[originalListIndex];
+
+  const clonedCards = listToCopy.cards.map(card => ({
+    ...card,
+    id: crypto.randomUUID(),
+  }));
+
+  const clonedList = {
+    ...listToCopy,
+    id: crypto.randomUUID(),
+    name: newName,
+    cards: clonedCards,
+  };
+
+  // insert the cloned list right after the original list
+  const updatedLists = [
+    ...board.lists.slice(0, originalListIndex + 1),
+    clonedList,
+    ...board.lists.slice(originalListIndex + 1),
+  ];
+
+  return updatedLists;
 }
 
 async function getById(boardId, filterBy = {}) {

--- a/src/store/actions/board-actions.js
+++ b/src/store/actions/board-actions.js
@@ -77,6 +77,19 @@ export async function deleteBoard(boardId) {
   }
 }
 
+export async function copyList(boardId, listId, newName) {
+  try {
+    const updatedLists = await boardService.copyList(boardId, listId, newName);
+    updateBoard(boardId, {
+      key: "lists",
+      value: updatedLists,
+    });
+  } catch (error) {
+    store.dispatch(setError(`Error copying list: ${error.message}`));
+    throw error;
+  }
+}
+
 export function setBoards(boards) {
   return { type: SET_BOARDS, payload: boards };
 }

--- a/src/store/actions/board-actions.js
+++ b/src/store/actions/board-actions.js
@@ -49,11 +49,11 @@ export async function createBoard(board) {
 }
 
 export async function updateBoard(
-  board,
+  boardId,
   { listId = null, cardId = null, key, value }
 ) {
   try {
-    const updatedBoard = await boardService.updateBoardWithActivity(board, {
+    const updatedBoard = await boardService.updateBoardWithActivity(boardId, {
       listId,
       cardId,
       key,


### PR DESCRIPTION
## 🎯 Description

This pull request introduces a copy menu form integrated into the list actions popover, which on submit, clones the desired list, inserts it after the original one, and updates the board object in the global state with the updated list of lists.

## 🔧 Changes

- 🟦 Created a reusable `ActionButton` component that wraps a MUI button.
- 📋 Added a `CopyListForm` that appears in the same popover as the list actions.
- 🛠️ Added board service functionality to clone a list and insert it after the original list.
- 🔄 Cloned the list on submit and updated the board object with the updated lists array.
- Refactor `boardService.copyList` and the `updateBoard` action along with `updateBoardWithActivity` to to be passed a `boardId` instead of a `board` object as an argument to prepare for future backend API that will probably be implement with an id reference.

## 📝 Notes
- The new components are designed for reusability and integration with existing UI patterns.
- Board state is updated immutably to ensure React state consistency.

## 🖥️ Demo

<details>
  <summary>Click to expand</summary>

  <p align="center">
    

https://github.com/user-attachments/assets/d79fd794-5dfb-478c-bc58-09fa689765c8


  </p>

</details>
