### PR TITLE
(BEFORE THIS PR, WE NEED "CATC_59: LABEL MENU" PR) feature: Add drag and drop functionality for lists [CATC_20-add-drag-and-drop-functionality-for-lists]

### DIFF
--- a/src/assets/styles/components/List.css
+++ b/src/assets/styles/components/List.css
@@ -14,6 +14,24 @@
   color: var(--gray1);
 }
 
+.list-container:active {
+  cursor: grabbing;
+}
+
+.list-container.dragging {
+  opacity: 0.5;
+  cursor: grabbing;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.3);
+}
+
+.list-container:not(.dragging) {
+  opacity: 1;
+}
+
+.lists-list li {
+  transition: transform 0.2s ease;
+}
+
 .list-header {
   display: flex;
   justify-content: space-between;

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -25,6 +25,11 @@ export function List({
   onRemoveLabel,
   isAddingCard,
   setActiveAddCardListId,
+  onDragStart,
+  onDragOver,
+  onDragEnd,
+  onDrop,
+  isDragging,
 }) {
   const [cards, setCards] = useState(list.cards);
   const [anchorEl, setAnchorEl] = useState(null);
@@ -131,7 +136,14 @@ export function List({
   }
 
   return (
-    <section className="list-container">
+    <section
+      className={`list-container ${isDragging ? "dragging" : ""}`}
+      draggable="true"
+      onDragStart={e => onDragStart(e, list.id)}
+      onDragOver={e => onDragOver(e, list.id)}
+      onDragEnd={onDragEnd}
+      onDrop={e => onDrop(e, list.id)}
+    >
       <div className="list-header">
         <h2>{list.name}</h2>
         <SquareIconButton

--- a/src/pages/BoardDetails.jsx
+++ b/src/pages/BoardDetails.jsx
@@ -147,7 +147,6 @@ export function BoardDetails() {
 
     if (!draggedListId || draggedListId === targetListId) return;
 
-    // Reorder lists in real-time for visual feedback
     const draggedIndex = displayedLists.findIndex(l => l.id === draggedListId);
     const targetIndex = displayedLists.findIndex(l => l.id === targetListId);
 
@@ -162,7 +161,7 @@ export function BoardDetails() {
 
   function handleDragEnd() {
     setDraggedListId(null);
-    // Reset to board's original order if drag was cancelled
+
     if (board && board.lists && !isUpdatingRef.current) {
       setDisplayedLists(board.lists);
     }
@@ -176,24 +175,19 @@ export function BoardDetails() {
       return;
     }
 
-    // Compare current order with board's original order
     const originalOrder = board.lists.map(l => l.id);
     const currentOrder = displayedLists.map(l => l.id);
     const orderChanged =
       JSON.stringify(originalOrder) !== JSON.stringify(currentOrder);
 
-    // Clear drag state
     setDraggedListId(null);
 
-    // If no change, just return without doing anything
     if (!orderChanged) {
       return;
     }
 
-    // Keep the current displayed order (optimistic update)
     const finalLists = [...displayedLists];
 
-    // Set updating flag
     isUpdatingRef.current = true;
 
     try {
@@ -205,15 +199,12 @@ export function BoardDetails() {
     } catch (error) {
       console.error("List reorder failed:", error);
       showErrorMsg("Unable to reorder lists");
-      // Revert to original order on error
+
       if (board && board.lists) {
         setDisplayedLists(board.lists);
       }
     } finally {
-      // Allow board updates to sync after a brief delay
-      // setTimeout(() => {
       isUpdatingRef.current = false;
-      // }, 100);
     }
   }
 


### PR DESCRIPTION
## 🎯 Description
Implements drag and drop functionality for reordering lists on the board. Users can now click and drag lists to reposition them, with real-time visual feedback showing the new order before dropping.

## 🔧 Changes
- Added drag and drop handlers (`onDragStart`, `onDragOver`, `onDragEnd`, `onDrop`) to List and BoardDetails components
- Implemented optimistic UI updates - lists stay in their new position immediately without waiting for backend confirmation
- Added visual feedback during drag (reduced opacity, grab cursor)
- Smart detection: no update or success message when dropping a list back to its original position
- Used `useRef` for `isUpdating` flag to avoid unnecessary re-renders

## 📝 Notes
- The drag and drop uses native HTML5 Drag and Drop API (no external libraries required)
- Lists reorder in real-time as you drag over other lists, providing instant visual feedback
- Backend updates happen asynchronously in the background
- If the backend update fails, the list order reverts with an error message

## 🧪 Testing
- Drag a list to a new position and verify it stays there
- Drag a list and drop it back in its original position - no update should occur
- Verify success/error messages display appropriately