### PR TITLE
feature/CATC_53-implement-move-list-in-list-actions

### DIFF
--- a/src/assets/styles/components/MoveListForm.css
+++ b/src/assets/styles/components/MoveListForm.css
@@ -1,0 +1,6 @@
+.move-list-form .MuiSelect-select,
+.move-list-form .MuiInputBase-input {
+  color: var(--form-input-color-default);
+  width: 100%;
+  box-sizing: border-box;
+}

--- a/src/assets/styles/main.css
+++ b/src/assets/styles/main.css
@@ -29,6 +29,7 @@
 @import "components/List";
 @import "components/ListActionsMenu";
 @import "components/CopyListForm";
+@import "components/MoveListForm";
 @import "components/Card";
 @import "components/FilterMenu";
 

--- a/src/assets/styles/setup/var.css
+++ b/src/assets/styles/setup/var.css
@@ -85,4 +85,6 @@
   --action-btn-color-default: #1f1f21;
   --action-btn-color-hover: var(--action-btn-color-default);
   --action-btn-color-active: var(--action-btn-color-default);
+
+  --form-input-color-default: #bfc1c4;
 }

--- a/src/components/CopyListForm.jsx
+++ b/src/components/CopyListForm.jsx
@@ -5,7 +5,7 @@ import Button from "@mui/material/Button";
 import Box from "@mui/material/Box";
 import ActionButton from "./ui/buttons/ActionButton";
 
-export default function CopyListForm({ initialValue, onSubmit, onCancel }) {
+export function CopyListForm({ initialValue, onCopy, onCancel }) {
   const textareaRef = useRef(null);
   const [textareaValue, setTextareaValue] = useState(initialValue || "");
 

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -8,6 +8,8 @@ import { SquareIconButton } from "./ui/buttons/SquareIconButton";
 import { boardService } from "../services/board";
 import { SCROLL_DIRECTION, useScrollTo } from "../hooks/useScrollTo";
 import { useNavigate, useLocation } from "react-router-dom";
+import { useDispatch } from "react-redux";
+import { setActiveListIndex } from "../store/actions/ui-actions";
 
 export function List({
   list,
@@ -19,9 +21,11 @@ export function List({
   isAddingCard,
   setActiveAddCardListId,
   onCopyList,
+  listIndex,
 }) {
   const [cards, setCards] = useState(list.cards);
   const [anchorEl, setAnchorEl] = useState(null);
+  const dispatch = useDispatch();
   const [newCardTitle, setNewCardTitle] = useState("");
   const navigate = useNavigate();
   const location = useLocation();
@@ -50,6 +54,7 @@ export function List({
 
   function handleMoreClick(event) {
     setAnchorEl(event.currentTarget);
+    dispatch(setActiveListIndex(listIndex));
   }
 
   function handleClose() {

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -8,7 +8,6 @@ import { SquareIconButton } from "./ui/buttons/SquareIconButton";
 import { boardService } from "../services/board";
 import { SCROLL_DIRECTION, useScrollTo } from "../hooks/useScrollTo";
 import { useNavigate, useLocation } from "react-router-dom";
-import { useDispatch } from "react-redux";
 import { setActiveListIndex } from "../store/actions/ui-actions";
 
 export function List({
@@ -25,7 +24,6 @@ export function List({
 }) {
   const [cards, setCards] = useState(list.cards);
   const [anchorEl, setAnchorEl] = useState(null);
-  const dispatch = useDispatch();
   const [newCardTitle, setNewCardTitle] = useState("");
   const navigate = useNavigate();
   const location = useLocation();
@@ -54,7 +52,7 @@ export function List({
 
   function handleMoreClick(event) {
     setAnchorEl(event.currentTarget);
-    dispatch(setActiveListIndex(listIndex));
+    setActiveListIndex(listIndex);
   }
 
   function handleClose() {

--- a/src/components/ListActionsMenu.jsx
+++ b/src/components/ListActionsMenu.jsx
@@ -16,9 +16,8 @@ export function ListActionsMenu({
   const [activeAction, setActiveAction] = useState(null);
 
   function handleMenuClick(key) {
-    if (key === "copy") {
-      setActiveAction("copy");
-    }
+    if (!listActionsMenuItems().find(item => item.key === key)) return;
+    setActiveAction(key);
   }
 
   function handleCopyList(listId, newName) {

--- a/src/components/ListActionsMenu.jsx
+++ b/src/components/ListActionsMenu.jsx
@@ -5,8 +5,8 @@ import MenuItem from "@mui/material/MenuItem";
 import ListItemText from "@mui/material/ListItemText";
 
 import { Popover } from "./Popover";
-import CopyListForm from "./CopyListForm";
-import MoveListForm from "./MoveListForm";
+import { CopyListForm } from "./CopyListForm";
+import { MoveListForm } from "./MoveListForm";
 
 export function ListActionsMenu({
   list,

--- a/src/components/ListActionsMenu.jsx
+++ b/src/components/ListActionsMenu.jsx
@@ -7,7 +7,6 @@ import ListItemText from "@mui/material/ListItemText";
 import { Popover } from "./Popover";
 import CopyListForm from "./CopyListForm";
 import MoveListForm from "./MoveListForm";
-import "../assets/styles/components/ListActionsMenu.css";
 
 export function ListActionsMenu({
   list,

--- a/src/components/ListActionsMenu.jsx
+++ b/src/components/ListActionsMenu.jsx
@@ -1,9 +1,12 @@
+import { useState } from "react";
+
 import MenuList from "@mui/material/MenuList";
 import MenuItem from "@mui/material/MenuItem";
 import ListItemText from "@mui/material/ListItemText";
-import { useState } from "react";
+
 import { Popover } from "./Popover";
 import CopyListForm from "./CopyListForm";
+import MoveListForm from "./MoveListForm";
 import "../assets/styles/components/ListActionsMenu.css";
 
 export function ListActionsMenu({
@@ -53,6 +56,15 @@ export function ListActionsMenu({
           initialValue={list.name}
           onSubmit={newName => handleCopyList(list.id, newName)}
           onCancel={handleCopyCancel}
+        />
+      ) : activeAction === "move" ? (
+        <MoveListForm
+          list={list}
+          onCancel={onPopoverClose}
+          onSubmit={() => {
+            setActiveAction(null);
+            onPopoverClose();
+          }}
         />
       ) : (
         <MenuList className="list-actions-menu" dense>

--- a/src/components/ListActionsMenu.jsx
+++ b/src/components/ListActionsMenu.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useSelector } from "react-redux";
 
 import MenuList from "@mui/material/MenuList";
 import MenuItem from "@mui/material/MenuItem";
@@ -7,6 +8,7 @@ import ListItemText from "@mui/material/ListItemText";
 import { Popover } from "./Popover";
 import { CopyListForm } from "./CopyListForm";
 import { MoveListForm } from "./MoveListForm";
+import { moveList } from "../store/actions/board-actions";
 
 export function ListActionsMenu({
   list,
@@ -16,6 +18,9 @@ export function ListActionsMenu({
   onCopyList,
 }) {
   const [activeAction, setActiveAction] = useState(null);
+  const boards = useSelector(state => state.boards.boards);
+  const currentBoard = useSelector(state => state.boards.board);
+  const activeListIndex = useSelector(state => state.ui.lists.activeListIndex);
 
   function handleMenuClick(key) {
     if (!listActionsMenuItems().find(item => item.key === key)) return;
@@ -24,6 +29,18 @@ export function ListActionsMenu({
 
   function handleCopyList(listId, newName) {
     onCopyList(listId, newName);
+    setActiveAction(null);
+    onClose();
+  }
+
+  function handleMoveList({ targetBoardId, targetPosition }) {
+    moveList(
+      currentBoard._id,
+      activeListIndex,
+      targetPosition,
+      targetBoardId,
+      currentBoard._id
+    );
     setActiveAction(null);
     onClose();
   }
@@ -58,12 +75,11 @@ export function ListActionsMenu({
         />
       ) : activeAction === "move" ? (
         <MoveListForm
-          list={list}
+          currentBoard={currentBoard}
+          boards={boards}
+          activeListIndex={activeListIndex}
           onCancel={onPopoverClose}
-          onSubmit={() => {
-            setActiveAction(null);
-            onPopoverClose();
-          }}
+          onSubmit={handleMoveList}
         />
       ) : (
         <MenuList className="list-actions-menu" dense>

--- a/src/components/ListActionsMenu.jsx
+++ b/src/components/ListActionsMenu.jsx
@@ -43,7 +43,7 @@ export function ListActionsMenu({
     );
 
     if (targetBoardId !== currentBoard._id) {
-      await loadBoards();
+      loadBoards();
     }
 
     setActiveAction(null);

--- a/src/components/ListActionsMenu.jsx
+++ b/src/components/ListActionsMenu.jsx
@@ -8,7 +8,7 @@ import ListItemText from "@mui/material/ListItemText";
 import { Popover } from "./Popover";
 import { CopyListForm } from "./CopyListForm";
 import { MoveListForm } from "./MoveListForm";
-import { moveList } from "../store/actions/board-actions";
+import { moveList, loadBoards } from "../store/actions/board-actions";
 
 export function ListActionsMenu({
   list,
@@ -33,14 +33,19 @@ export function ListActionsMenu({
     onClose();
   }
 
-  function handleMoveList({ targetBoardId, targetPosition }) {
-    moveList(
+  async function handleMoveList({ targetBoardId, targetPosition }) {
+    await moveList(
       currentBoard._id,
       activeListIndex,
       targetPosition,
       targetBoardId,
       currentBoard._id
     );
+
+    if (targetBoardId !== currentBoard._id) {
+      await loadBoards();
+    }
+
     setActiveAction(null);
     onClose();
   }

--- a/src/components/MoveListForm.jsx
+++ b/src/components/MoveListForm.jsx
@@ -1,5 +1,3 @@
-import { useEffect } from "react";
-import { useSelector } from "react-redux";
 import { useFormState } from "../hooks/useFormState";
 import FormControl from "@mui/material/FormControl";
 import Select from "@mui/material/Select";
@@ -8,29 +6,24 @@ import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
 import ActionButton from "./ui/buttons/ActionButton";
-import { loadBoards } from "../store/actions/board-actions";
 
-export function MoveListForm({ onSubmit, onCancel }) {
-  const boards = useSelector(state => state.boards.boards);
-  const currentBoard = useSelector(state => state.boards.board);
-  const activeListIndex = useSelector(state => state.ui.lists.activeListIndex);
-
-  useEffect(() => {
-    if (!boards || boards.length === 0) {
-      loadBoards();
-    }
-  }, []);
-
+export function MoveListForm({
+  currentBoard,
+  boards,
+  activeListIndex,
+  onSubmit,
+  onCancel,
+}) {
   const defaultBoardId =
     currentBoard?._id || (boards[0] && boards[0]._id) || "";
-  const selectedBoard = boards.find(b => b._id === currentBoard._id) ||
-    boards.find(b => b._id === defaultBoardId) ||
-    boards[0] || { lists: [] };
 
   const { values, handleChange, setValues } = useFormState({
     boardId: defaultBoardId,
     position: activeListIndex || 0,
   });
+
+  const selectedBoard = boards.find(b => b._id === values.boardId) ||
+    boards[0] || { lists: [] };
 
   // handle position when board changes
   function handleBoardChange(e) {
@@ -45,10 +38,9 @@ export function MoveListForm({ onSubmit, onCancel }) {
 
   function handleSubmit(e) {
     e.preventDefault();
-    onSubmit({
-      boardId: values.boardId,
-      position: values.position,
-    });
+    const { boardId: targetBoardId, position: targetPosition } = values;
+
+    onSubmit({ targetBoardId, targetPosition });
   }
 
   return (

--- a/src/components/MoveListForm.jsx
+++ b/src/components/MoveListForm.jsx
@@ -1,0 +1,123 @@
+import { useEffect } from "react";
+import { useSelector } from "react-redux";
+import { useFormState } from "../hooks/useFormState";
+import FormControl from "@mui/material/FormControl";
+import Select from "@mui/material/Select";
+import MenuItem from "@mui/material/MenuItem";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Typography from "@mui/material/Typography";
+import ActionButton from "./ui/buttons/ActionButton";
+import { loadBoards } from "../store/actions/board-actions";
+
+export default function MoveListForm({ onSubmit, onCancel }) {
+  const boards = useSelector(state => state.boards.boards);
+  const currentBoard = useSelector(state => state.boards.board);
+  const activeListIndex = useSelector(state => state.ui.lists.activeListIndex);
+
+  useEffect(() => {
+    if (!boards || boards.length === 0) {
+      loadBoards();
+    }
+  }, []);
+
+  const defaultBoardId =
+    currentBoard?._id || (boards[0] && boards[0]._id) || "";
+  const selectedBoard = boards.find(b => b._id === currentBoard._id) ||
+    boards.find(b => b._id === defaultBoardId) ||
+    boards[0] || { lists: [] };
+
+  const { values, handleChange, setValues } = useFormState({
+    boardId: defaultBoardId,
+    position: activeListIndex || 0,
+  });
+
+  // handle position when board changes
+  function handleBoardChange(e) {
+    handleChange(e);
+    const boardId = e.target.value;
+    const position = boardId === currentBoard._id ? activeListIndex : 0;
+    setValues(v => ({
+      ...v,
+      position,
+    }));
+  }
+
+  function handleSubmit(e) {
+    e.preventDefault();
+    onSubmit({
+      boardId: values.boardId,
+      position: values.position,
+    });
+  }
+
+  return (
+    <form className="move-list-form" onSubmit={handleSubmit}>
+      <Box mb={2}>
+        <Typography
+          variant="subtitle2"
+          component="label"
+          htmlFor="move-list-board-select"
+          sx={{ mb: 0.5, fontWeight: 500 }}
+        >
+          Board
+        </Typography>
+        <FormControl fullWidth margin="dense">
+          <Select
+            id="move-list-board-select"
+            name="boardId"
+            value={boards.length > 0 ? values.boardId : ""}
+            onChange={handleBoardChange}
+            disabled={boards.length === 0}
+            size="small"
+          >
+            {boards.map(b => (
+              <MenuItem key={b._id} value={b._id}>
+                {b.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Box>
+      <Box mb={2}>
+        <Typography
+          variant="subtitle2"
+          component="label"
+          htmlFor="move-list-position-select"
+          sx={{ mb: 0.5, fontWeight: 500 }}
+        >
+          Position
+        </Typography>
+        <FormControl fullWidth margin="dense">
+          <Select
+            id="move-list-position-select"
+            name="position"
+            value={
+              selectedBoard.lists && selectedBoard.lists.length > 0
+                ? values.position
+                : ""
+            }
+            onChange={handleChange}
+            disabled={!selectedBoard.lists || selectedBoard.lists.length === 0}
+            size="small"
+          >
+            {selectedBoard.lists &&
+              selectedBoard.lists.map((list, index) => (
+                <MenuItem key={index} value={index}>
+                  {index + 1}
+                </MenuItem>
+              ))}
+          </Select>
+        </FormControl>
+      </Box>
+      <Box display="flex" gap={2} mt={2}>
+        <ActionButton type="submit" variant="contained" color="primary">
+          Move
+        </ActionButton>
+        <Button type="button" variant="outlined" onClick={onCancel}>
+          Cancel
+        </Button>
+      </Box>
+    </form>
+  );
+}

--- a/src/components/MoveListForm.jsx
+++ b/src/components/MoveListForm.jsx
@@ -10,7 +10,7 @@ import Typography from "@mui/material/Typography";
 import ActionButton from "./ui/buttons/ActionButton";
 import { loadBoards } from "../store/actions/board-actions";
 
-export default function MoveListForm({ onSubmit, onCancel }) {
+export function MoveListForm({ onSubmit, onCancel }) {
   const boards = useSelector(state => state.boards.boards);
   const currentBoard = useSelector(state => state.boards.board);
   const activeListIndex = useSelector(state => state.ui.lists.activeListIndex);

--- a/src/components/MoveListForm.jsx
+++ b/src/components/MoveListForm.jsx
@@ -14,16 +14,12 @@ export function MoveListForm({
   onSubmit,
   onCancel,
 }) {
-  const defaultBoardId =
-    currentBoard?._id || (boards[0] && boards[0]._id) || "";
-
+  const defaultBoardId = currentBoard._id;
   const { values, handleChange, setValues } = useFormState({
     boardId: defaultBoardId,
     position: activeListIndex || 0,
   });
-
-  const selectedBoard = boards.find(b => b._id === values.boardId) ||
-    boards[0] || { lists: [] };
+  const selectedBoard = boards.find(b => b._id === values.boardId);
 
   // handle position when board changes
   function handleBoardChange(e) {

--- a/src/hooks/useFormState.js
+++ b/src/hooks/useFormState.js
@@ -1,0 +1,26 @@
+import { useState } from "react";
+
+export function useFormState(initialValues = {}) {
+  const [values, setValues] = useState(initialValues);
+
+  function handleChange(e) {
+    const { name, value, type, checked } = e.target;
+    setValues(function (prev) {
+      return {
+        ...prev,
+        [name]:
+          type === "checkbox"
+            ? checked
+            : type === "number"
+            ? Number(value)
+            : value,
+      };
+    });
+  }
+
+  function resetForm() {
+    setValues(initialValues);
+  }
+
+  return { values, handleChange, setValues, resetForm };
+}

--- a/src/pages/BoardDetails.jsx
+++ b/src/pages/BoardDetails.jsx
@@ -105,7 +105,7 @@ export function BoardDetails() {
       </header>
       <div className="board-canvas" ref={boardCanvasRef}>
         <ul className="lists-list">
-          {board.lists.map(list => (
+          {board.lists.map((list, listIndex) => (
             <li key={list.id}>
               <List
                 key={list.id}
@@ -118,6 +118,7 @@ export function BoardDetails() {
                 onCopyList={onCopyList}
                 isAddingCard={activeAddCardListId === list.id}
                 setActiveAddCardListId={setActiveAddCardListId}
+                listIndex={listIndex}
               />
             </li>
           ))}

--- a/src/pages/BoardDetails.jsx
+++ b/src/pages/BoardDetails.jsx
@@ -9,6 +9,7 @@ import LockOutlineRounded from "@mui/icons-material/LockOutlineRounded";
 
 import {
   loadBoard,
+  loadBoards,
   updateBoard,
   copyList,
 } from "../store/actions/board-actions";
@@ -29,6 +30,7 @@ export function BoardDetails() {
   const params = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
   const board = useSelector(state => state.boards.board);
+  const boards = useSelector(state => state.boards.boards);
   const [labelsIsOpen, setLabelsIsOpen] = useState(false);
   const boardCanvasRef = useRef(null);
   const scrollBoardToEnd = useScrollTo(boardCanvasRef);
@@ -36,6 +38,9 @@ export function BoardDetails() {
 
   useEffect(() => {
     loadBoard(params.boardId, filters);
+    if (!boards || boards.length === 0) {
+      loadBoards();
+    }
   }, [params.boardId, filters]);
 
   useEffect(() => {

--- a/src/services/board/board-service-local.js
+++ b/src/services/board/board-service-local.js
@@ -120,7 +120,8 @@ async function moveCrossBoard(
     lists: updatedTargetLists,
   });
 
-  await Promise.all([save(updatedSourceBoard), save(updatedTargetBoard)]);
+  await save(updatedSourceBoard);
+  await save(updatedTargetBoard);
 
   return currentBoardId === sourceBoard._id
     ? updatedSourceLists

--- a/src/store/actions/board-actions.js
+++ b/src/store/actions/board-actions.js
@@ -4,6 +4,7 @@ import {
   UPDATE_BOARD,
   DELETE_BOARD,
   SET_BOARD,
+  MOVE_LIST,
   SET_LOADING,
   SET_ERROR,
   SET_FILTERS,
@@ -131,6 +132,29 @@ export function editCardAction(card, listId) {
   return { type: EDIT_CARD, payload: { card, listId } };
 }
 
+export async function moveList(
+  sourceBoardId,
+  sourceIndex,
+  targetIndex,
+  targetBoardId,
+  currentBoardId
+) {
+  try {
+    const updatedLists = await boardService.moveList(
+      sourceBoardId,
+      sourceIndex,
+      targetIndex,
+      targetBoardId,
+      currentBoardId
+    );
+    store.dispatch(moveListAction(updatedLists));
+    return updatedLists;
+  } catch (error) {
+    store.dispatch(setError(`Error moving list: ${error.message}`));
+    throw error;
+  }
+}
+
 export function setBoards(boards) {
   return { type: SET_BOARDS, payload: boards };
 }
@@ -165,4 +189,8 @@ export function setFilters(filterBy) {
 
 export function clearAllFilters() {
   return { type: CLEAR_ALL_FILTERS };
+}
+
+export function moveListAction(lists) {
+  return { type: MOVE_LIST, payload: lists };
 }

--- a/src/store/actions/ui-actions.js
+++ b/src/store/actions/ui-actions.js
@@ -1,5 +1,10 @@
 import { SET_ACTIVE_LIST_INDEX } from "../reducers/ui-reducer";
+import { store } from "../store";
+
+export function setActiveListIndexAction(index) {
+  return { type: SET_ACTIVE_LIST_INDEX, payload: index };
+}
 
 export function setActiveListIndex(index) {
-  return { type: SET_ACTIVE_LIST_INDEX, payload: index };
+  store.dispatch(setActiveListIndexAction(index));
 }

--- a/src/store/actions/ui-actions.js
+++ b/src/store/actions/ui-actions.js
@@ -1,0 +1,5 @@
+import { SET_ACTIVE_LIST_INDEX } from "../reducers/ui-reducer";
+
+export function setActiveListIndex(index) {
+  return { type: SET_ACTIVE_LIST_INDEX, payload: index };
+}

--- a/src/store/reducers/board-reducer.js
+++ b/src/store/reducers/board-reducer.js
@@ -8,6 +8,7 @@ export const UPDATE_BOARD = "UPDATE_BOARD";
 export const ADD_CARD = "ADD_CARD";
 export const EDIT_CARD = "EDIT_CARD";
 export const DELETE_CARD = "DELETE_CARD";
+export const MOVE_LIST = "MOVE_LIST";
 export const SET_LOADING = "boards/SET_LOADING";
 export const SET_ERROR = "boards/SET_ERROR";
 export const SET_FILTERS = "boards/SET_FILTERS";
@@ -34,6 +35,14 @@ export function boardReducer(state = initialState, action) {
       return { ...state, boards: [...state.boards, action.payload] };
     case UPDATE_BOARD:
       return { ...state, board: action.payload };
+    case MOVE_LIST:
+      return {
+        ...state,
+        board: {
+          ...state.board,
+          lists: action.payload,
+        },
+      };
     case ADD_CARD:
       return {
         ...state,

--- a/src/store/reducers/ui-reducer.js
+++ b/src/store/reducers/ui-reducer.js
@@ -1,0 +1,22 @@
+export const SET_ACTIVE_LIST_INDEX = "ui/lists/SET_ACTIVE_LIST_INDEX";
+
+const initialState = {
+  lists: {
+    activeListIndex: null,
+  },
+};
+
+export function uiReducer(state = initialState, action) {
+  switch (action.type) {
+    case SET_ACTIVE_LIST_INDEX:
+      return {
+        ...state,
+        lists: {
+          ...state.lists,
+          activeListIndex: action.payload,
+        },
+      };
+    default:
+      return state;
+  }
+}

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,10 +1,12 @@
 import { legacy_createStore as createStore, combineReducers } from "redux";
 import { boardReducer } from "./reducers/board-reducer";
 import { userReducer } from "./reducers/user-reducer";
+import { uiReducer } from "./reducers/ui-reducer";
 
 const rootReducer = combineReducers({
   boards: boardReducer,
   users: userReducer,
+  ui: uiReducer,
 });
 
 const middleware = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__


### PR DESCRIPTION
## 🎯 Description
Implements the ability to move lists within the same board or between different boards with a user-friendly form interface. Adds UI state management for active list tracking and a custom form hook for lightweight form handling.

## 🔧 Changes
🔄 __Added UI slice for list state management__ - Eliminates prop drilling by centralizing active list state in Redux.
📝 __Implemented moveList service function__ - Supports both same-board and cross-board list movements.
🎣 __Created useFormState custom hook__ - Minimalistic form state management avoiding library overhead for simple forms.
🎨 __Built MoveListForm component__ - Material-UI form for selecting target board and position with dynamic options.

<details>
  <summary>Watch Demo Video</summary>

  <p align="center">
  <h3>Cross Board Example</h3>

https://github.com/user-attachments/assets/259939bc-e9f0-40ab-9fea-85ad14f95c30

<h3>Same Board Example</h3>

https://github.com/user-attachments/assets/6c385623-ffaa-4b80-b410-f132785bf8c4


  </p>

</details>

