### PR TITLE
Fixed the bug of the edit card from the card itself #CATC-69

### DIFF
--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -7,18 +7,20 @@ import {
 import CardPopover from "./CardPopover";
 import { Box } from "@mui/material";
 import { useState } from "react";
+import { useParams } from "react-router-dom";
+import { editCard, deleteCard } from "../store/actions/board-actions";
 
 export function Card({
   card,
+  listId,
   labels = [],
   onClickCard,
-  onRemoveCard,
-  onUpdateCard,
   labelsIsOpen,
   setLabelsIsOpen,
 }) {
   const [anchorEl, setAnchorEl] = useState(null);
   const [title, setTitle] = useState(card.title);
+  const { boardId } = useParams();
 
   function handleClickCard() {
     onClickCard(card);
@@ -42,11 +44,16 @@ export function Card({
   function handleSave() {
     card.title = title;
     handleClose();
-    onUpdateCard({ ...card, title });
+    handleUpdateCard({ ...card, title });
+  }
+
+  function handleUpdateCard(card) {
+    editCard(boardId, card, listId);
+    handleClose();
   }
 
   function handleDelete() {
-    onRemoveCard(card.id);
+    deleteCard(boardId, card.id, listId);
     handleClose();
   }
 

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -39,15 +39,6 @@ export function List({
     });
   }
 
-  async function onRemoveCard(cardId) {
-    await onRemoveList(list.id);
-  }
-
-  async function onUpdateCard(card) {
-    setCards(prev => [...prev, card]);
-    await onUpdateList(list, { cards });
-  }
-
   function handleMoreClick(event) {
     setAnchorEl(event.currentTarget);
   }
@@ -132,10 +123,9 @@ export function List({
               <li key={card.id}>
                 <Card
                   card={card}
+                  listId={list.id}
                   labels={cardLabels}
                   onClickCard={card => handleOpenModal(card)}
-                  onRemoveCard={onRemoveCard}
-                  onUpdateCard={onUpdateCard}
                   labelsIsOpen={labelsIsOpen}
                   setLabelsIsOpen={setLabelsIsOpen}
                 />


### PR DESCRIPTION
## 🎯 Description
This fixes the issue where editing a card from within the card itself was creating a duplicate instead of updating it.

## 🔧 Changes

* Fixed the bug by using the editCard action
* Moved the edit card into card
* Moved the delete card to the card
* Removed unnecessary code 


## 📝 Notes

This also effectively implements deleting a card directly from the card view, thanks to the simplified logic.


## 🖥️ Demo

<details>
  <summary>Watch Demo Video</summary>

  <p align="center">
    <video src="YOUR_VIDEO_URL_HERE" controls width="600"></video>
  </p>

</details>
