### PR TITLE
feature/CATC_55-implement-move-all-cards-in-the-list-actions

### DIFF
--- a/src/assets/styles/components/ListActionsMenu.css
+++ b/src/assets/styles/components/ListActionsMenu.css
@@ -1,3 +1,3 @@
-.list-actions-menu .MuiMenuItem-root:hover {
+.popover-menu .MuiMenuItem-root:hover {
   background-color: #ceced912;
 }

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -21,6 +21,7 @@ export function List({
   setActiveAddCardListId,
   onCopyList,
   listIndex,
+  onMoveAllCards,
 }) {
   const [cards, setCards] = useState(list.cards);
   const [anchorEl, setAnchorEl] = useState(null);
@@ -180,6 +181,7 @@ export function List({
         onEditList={handleEditList}
         onDeleteList={handleDeleteList}
         onCopyList={onCopyList}
+        onMoveAllCards={onMoveAllCards}
       />
     </section>
   );

--- a/src/components/ListActionsMenu.jsx
+++ b/src/components/ListActionsMenu.jsx
@@ -18,6 +18,7 @@ export function ListActionsMenu({
   isOpen,
   onClose,
   onCopyList,
+  onMoveAllCards,
 }) {
   const [activeAction, setActiveAction] = useState(null);
   const boards = useSelector(state => state.boards.boards);
@@ -27,6 +28,12 @@ export function ListActionsMenu({
   function handleMenuClick(key) {
     if (!listActionsMenuItems().find(item => item.key === key)) return;
     setActiveAction(key);
+  }
+
+  function handleMoveAllCards(destinationListId) {
+    onMoveAllCards(list.id, destinationListId);
+    setActiveAction(null);
+    onClose();
   }
 
   function handleCopyList(listId, newName) {
@@ -86,12 +93,12 @@ export function ListActionsMenu({
             <MenuItem
               key={listItem.id}
               disabled={listItem.id === list.id}
-              onClick={() => handleMenuClick(listItem.id)}
+              onClick={() => handleMoveAllCards(listItem.id)}
             >
               <ListItemText>{listItem.name}</ListItemText>
             </MenuItem>
           ))}
-          <MenuItem onClick={() => handleMenuClick("new")}>
+          <MenuItem onClick={() => handleMoveAllCards("new")}>
             <ListItemText>New List</ListItemText>
           </MenuItem>
         </MenuList>

--- a/src/components/ListActionsMenu.jsx
+++ b/src/components/ListActionsMenu.jsx
@@ -87,7 +87,7 @@ export function ListActionsMenu({
           onCancel={handleCopyCancel}
         />
       ) : activeAction === "moveAll" ? (
-        <MenuList className="list-actions-menu" dense>
+        <MenuList className="popover-menu" dense>
           {currentBoard.lists.map(listItem => (
             <MenuItem
               key={listItem.id}
@@ -110,7 +110,7 @@ export function ListActionsMenu({
           onSubmit={handleMoveList}
         />
       ) : (
-        <MenuList className="list-actions-menu" dense>
+        <MenuList className="list-actions-menu popover-menu" dense>
           {listActionsMenuItems().map(({ label, key }) => (
             <MenuItem key={key} onClick={() => handleMenuClick(key)}>
               <ListItemText>{label}</ListItemText>

--- a/src/components/ListActionsMenu.jsx
+++ b/src/components/ListActionsMenu.jsx
@@ -31,7 +31,6 @@ export function ListActionsMenu({
 
   function handleMoveAllCards(destinationListId) {
     onMoveAllCards(list.id, destinationListId);
-    setActiveAction(null);
     onClose();
   }
 
@@ -63,7 +62,6 @@ export function ListActionsMenu({
   }
 
   function onPopoverClose() {
-    setActiveAction(null);
     onClose();
   }
 
@@ -72,13 +70,14 @@ export function ListActionsMenu({
       className="list-actions-menu-popover"
       anchorEl={anchorEl}
       open={isOpen}
-      onClose={onPopoverClose}
+      onClose={onClose}
       title="List actions"
       anchorOrigin={{
         vertical: "bottom",
         horizontal: "left",
       }}
       paperProps={{ sx: { mt: 1 } }}
+      slotProps={{ transition: { onExited: () => setActiveAction(null) } }}
     >
       {activeAction === "copy" ? (
         <CopyListForm

--- a/src/components/ListActionsMenu.jsx
+++ b/src/components/ListActionsMenu.jsx
@@ -7,7 +7,6 @@ import ListItemText from "@mui/material/ListItemText";
 
 import { Popover } from "./Popover";
 import "../assets/styles/components/ListActionsMenu.css";
-import { useSelector } from "react-redux";
 import { CopyListForm } from "./CopyListForm";
 import { MoveListForm } from "./MoveListForm";
 import { moveList, loadBoards } from "../store/actions/board-actions";

--- a/src/components/ListActionsMenu.jsx
+++ b/src/components/ListActionsMenu.jsx
@@ -6,6 +6,8 @@ import MenuItem from "@mui/material/MenuItem";
 import ListItemText from "@mui/material/ListItemText";
 
 import { Popover } from "./Popover";
+import "../assets/styles/components/ListActionsMenu.css";
+import { useSelector } from "react-redux";
 import { CopyListForm } from "./CopyListForm";
 import { MoveListForm } from "./MoveListForm";
 import { moveList, loadBoards } from "../store/actions/board-actions";
@@ -78,6 +80,21 @@ export function ListActionsMenu({
           onCopy={newName => handleCopyList(list.id, newName)}
           onCancel={handleCopyCancel}
         />
+      ) : activeAction === "moveAll" ? (
+        <MenuList className="list-actions-menu" dense>
+          {currentBoard.lists.map(listItem => (
+            <MenuItem
+              key={listItem.id}
+              disabled={listItem.id === list.id}
+              onClick={() => handleMenuClick(listItem.id)}
+            >
+              <ListItemText>{listItem.name}</ListItemText>
+            </MenuItem>
+          ))}
+          <MenuItem onClick={() => handleMenuClick("new")}>
+            <ListItemText>New List</ListItemText>
+          </MenuItem>
+        </MenuList>
       ) : activeAction === "move" ? (
         <MoveListForm
           currentBoard={currentBoard}

--- a/src/components/Popover.jsx
+++ b/src/components/Popover.jsx
@@ -12,6 +12,7 @@ export function Popover({
   children,
   showClose = true,
   paperProps = {},
+  slotProps = {},
   ...popoverProps
 }) {
   return (
@@ -24,6 +25,7 @@ export function Popover({
           className: "popover-paper",
           ...paperProps,
         },
+        ...slotProps,
       }}
       {...popoverProps}
     >

--- a/src/pages/BoardDetails.jsx
+++ b/src/pages/BoardDetails.jsx
@@ -14,6 +14,7 @@ import {
   copyList,
   moveAllCardsToList,
   createListAndMoveAllCards,
+  createList,
 } from "../store/actions/board-actions";
 import { Footer } from "../components/Footer";
 import { List } from "../components/List";
@@ -77,10 +78,7 @@ export function BoardDetails() {
   }
 
   async function onAddList(newList) {
-    const options = { listId: null, cardId: null };
-    const updates = { lists: [...board.lists, newList] };
-    await updateBoard(board._id, updates, options);
-    crete;
+    await createList(board._id, newList);
 
     requestAnimationFrame(() =>
       scrollBoardToEnd({ direction: SCROLL_DIRECTION.HORIZONTAL })

--- a/src/pages/BoardDetails.jsx
+++ b/src/pages/BoardDetails.jsx
@@ -13,7 +13,7 @@ import {
   updateBoard,
   copyList,
   moveAllCardsToList,
-  createNewList,
+  createNewListAndMoveAllCards,
 } from "../store/actions/board-actions";
 import { Footer } from "../components/Footer";
 import { List } from "../components/List";
@@ -89,8 +89,7 @@ export function BoardDetails() {
   async function onMoveAllCards(sourceListId, targetListId) {
     try {
       if (targetListId === "new") {
-        const newList = await createNewList(board._id, "New List");
-        await moveAllCardsToList(board._id, sourceListId, newList.id);
+        await createNewListAndMoveAllCards(board._id, sourceListId, "New List");
       } else {
         await moveAllCardsToList(board._id, sourceListId, targetListId);
       }
@@ -135,7 +134,6 @@ export function BoardDetails() {
                 onUpdateList={onUpdateList}
                 onCopyList={onCopyList}
                 onMoveAllCards={onMoveAllCards}
-                onCreateListAndMoveCards={onCreateListAndMoveCards}
                 isAddingCard={activeAddCardListId === list.id}
                 setActiveAddCardListId={setActiveAddCardListId}
                 listIndex={listIndex}

--- a/src/pages/BoardDetails.jsx
+++ b/src/pages/BoardDetails.jsx
@@ -13,7 +13,7 @@ import {
   updateBoard,
   copyList,
   moveAllCardsToList,
-  createNewListAndMoveAllCards,
+  createListAndMoveAllCards,
 } from "../store/actions/board-actions";
 import { Footer } from "../components/Footer";
 import { List } from "../components/List";
@@ -80,6 +80,7 @@ export function BoardDetails() {
     const options = { listId: null, cardId: null };
     const updates = { lists: [...board.lists, newList] };
     await updateBoard(board._id, updates, options);
+    crete;
 
     requestAnimationFrame(() =>
       scrollBoardToEnd({ direction: SCROLL_DIRECTION.HORIZONTAL })
@@ -89,7 +90,7 @@ export function BoardDetails() {
   async function onMoveAllCards(sourceListId, targetListId) {
     try {
       if (targetListId === "new") {
-        await createNewListAndMoveAllCards(board._id, sourceListId, "New List");
+        await createListAndMoveAllCards(board._id, sourceListId, "New List");
       } else {
         await moveAllCardsToList(board._id, sourceListId, targetListId);
       }

--- a/src/pages/BoardDetails.jsx
+++ b/src/pages/BoardDetails.jsx
@@ -12,8 +12,7 @@ import {
   loadBoards,
   updateBoard,
   copyList,
-  moveAllCardsToList,
-  createListAndMoveAllCards,
+  moveAllCards,
   createList,
 } from "../store/actions/board-actions";
 import { Footer } from "../components/Footer";
@@ -88,9 +87,11 @@ export function BoardDetails() {
   async function onMoveAllCards(sourceListId, targetListId) {
     try {
       if (targetListId === "new") {
-        await createListAndMoveAllCards(board._id, sourceListId, "New List");
+        await moveAllCards(board._id, sourceListId, null, {
+          newListName: "New List",
+        });
       } else {
-        await moveAllCardsToList(board._id, sourceListId, targetListId);
+        await moveAllCards(board._id, sourceListId, targetListId);
       }
     } catch (error) {
       console.error("Move all cards failed:", error);

--- a/src/pages/BoardDetails.jsx
+++ b/src/pages/BoardDetails.jsx
@@ -12,6 +12,8 @@ import {
   loadBoards,
   updateBoard,
   copyList,
+  moveAllCardsToList,
+  createNewList,
 } from "../store/actions/board-actions";
 import { Footer } from "../components/Footer";
 import { List } from "../components/List";
@@ -84,6 +86,19 @@ export function BoardDetails() {
     );
   }
 
+  async function onMoveAllCards(sourceListId, targetListId) {
+    try {
+      if (targetListId === "new") {
+        const newList = await createNewList(board._id, "New List");
+        await moveAllCardsToList(board._id, sourceListId, newList.id);
+      } else {
+        await moveAllCardsToList(board._id, sourceListId, targetListId);
+      }
+    } catch (error) {
+      console.error("Move all cards failed:", error);
+    }
+  }
+
   if (!board) return <div>Loading board...</div>;
 
   return (
@@ -119,6 +134,8 @@ export function BoardDetails() {
                 onRemoveList={onRemoveList}
                 onUpdateList={onUpdateList}
                 onCopyList={onCopyList}
+                onMoveAllCards={onMoveAllCards}
+                onCreateListAndMoveCards={onCreateListAndMoveCards}
                 isAddingCard={activeAddCardListId === list.id}
                 setActiveAddCardListId={setActiveAddCardListId}
                 listIndex={listIndex}

--- a/src/services/board/board-service-local.js
+++ b/src/services/board/board-service-local.js
@@ -21,6 +21,8 @@ export const boardService = {
   deleteCard,
   getEmptyList,
   copyList,
+  moveAllCards,
+  createNewList,
 };
 window.bs = boardService;
 
@@ -289,6 +291,45 @@ export async function deleteCard(boardId, cardId, listId) {
 //     throw error;
 //   }
 // }
+
+export async function moveAllCards(boardId, sourceListId, targetListId) {
+  try {
+    const board = await getById(boardId);
+    if (!board) throw new Error("Board not found");
+
+    const sourceList = _findList(board, sourceListId);
+    const targetList = _findList(board, targetListId);
+
+    const cardsToMove = [...sourceList.cards];
+    targetList.cards.push(...cardsToMove);
+    sourceList.cards = [];
+
+    const updatedBoard = await updateBoard(boardId, { lists: board.lists });
+    return updatedBoard.lists;
+  } catch (error) {
+    console.error("Cannot move all cards:", error);
+    throw error;
+  }
+}
+
+export async function createNewList(boardId, listName = "New List") {
+  try {
+    const board = await getById(boardId);
+    if (!board) throw new Error("Board not found");
+
+    const newList = {
+      ...getEmptyList(),
+      name: listName,
+    };
+
+    const updatedLists = [...board.lists, newList];
+    await updateBoard(boardId, { lists: updatedLists });
+    return newList;
+  } catch (error) {
+    console.error("Cannot create new list:", error);
+    throw error;
+  }
+}
 
 export function getEmptyList() {
   return {

--- a/src/services/board/board-service-local.js
+++ b/src/services/board/board-service-local.js
@@ -22,8 +22,8 @@ export const boardService = {
   getEmptyList,
   copyList,
   moveAllCards,
-  createNewList,
-  createNewListAndMoveAllCards,
+  createList,
+  createListAndMoveAllCards,
 };
 window.bs = boardService;
 
@@ -280,7 +280,7 @@ export async function moveAllCards(boardId, sourceListId, targetListId) {
   }
 }
 
-export async function createNewList(boardId, listName = "New List") {
+export async function createList(boardId, listName = "New List") {
   try {
     const board = await getById(boardId);
     if (!board) throw new Error("Board not found");
@@ -307,7 +307,7 @@ export function getEmptyList() {
   };
 }
 
-export async function createNewListAndMoveAllCards(
+export async function createListAndMoveAllCards(
   boardId,
   sourceListId,
   listName = "New List"

--- a/src/services/board/board-service-local.js
+++ b/src/services/board/board-service-local.js
@@ -258,39 +258,6 @@ export async function deleteCard(boardId, cardId, listId) {
     throw error;
   }
 }
-// async function updateBoardWithActivity(
-//   boardId,
-//   { listId = null, cardId = null, key, value }
-// ) {
-//   try {
-//     if (!boardId || !key) throw new Error("Board and key are required");
-
-//     const board = await getById(boardId);
-//     if (!board) throw new Error("Board not found");
-
-//     let { board: updatedBoard, prevValue } = _applyBoardUpdate(
-//       board,
-//       { key, value },
-//       listId,
-//       cardId
-//     );
-
-//     updatedBoard = _addBoardActivity(
-//       updatedBoard,
-//       key,
-//       value,
-//       prevValue,
-//       listId,
-//       cardId
-//     );
-
-//     return save(updatedBoard);
-//   } catch (error) {
-//     console.error("Cannot update board:", error);
-
-//     throw error;
-//   }
-// }
 
 export async function moveAllCards(boardId, sourceListId, targetListId) {
   try {
@@ -339,50 +306,6 @@ export function getEmptyList() {
   };
 }
 
-// function _applyBoardUpdate(
-//   board,
-//   { key, value },
-//   listId = null,
-//   cardId = null
-// ) {
-//   try {
-//     let prevValue;
-
-//     if (cardId) {
-//       if (!listId) throw new Error("Card update requires listId");
-
-//       const list = board.lists?.find(l => l.id === listId);
-//       if (!list) throw new Error("List not found");
-
-//       const card = list.cards?.find(c => c.id === cardId);
-//       if (!card) throw new Error("Card not found");
-
-//       if (!key && value) {
-//         const index = list.cards.findIndex(c => c.id === cardId);
-//         prevValue = card;
-//         let newcard = { ...card, ...value };
-//         list.cards[index] = newcard;
-//       } else {
-//         prevValue = card[key];
-//         card[key] = value;
-//       }
-//     } else if (listId) {
-//       const list = board.lists?.find(l => l.id === listId);
-//       if (!list) throw new Error("List not found");
-
-//       prevValue = list[key];
-//       list[key] = value;
-//     } else {
-//       prevValue = board[key];
-//       board[key] = value;
-//     }
-
-//     return { board, prevValue };
-//   } catch (error) {
-//     console.warn("Board updated failed:", error.message);
-
-//     throw error;
-//   }
 function updateBoardFields(board, updates) {
   return { ...board, ...updates };
 }
@@ -407,52 +330,6 @@ function updateCardFields(board, listId, cardId, updates) {
   const updatedList = { ...list, cards: updatedCards };
   return updateListFields(board, listId, updatedList);
 }
-
-/* _applyBoardUpdate removed: logic now handled directly in updateBoard */
-
-// function _addBoardActivity(
-//   board,
-//   key,
-//   value,
-//   prevValue,
-//   listId = null,
-//   cardId = null
-// ) {
-//   const activity = _createActivity(
-//     board._id,
-//     key,
-//     value,
-//     prevValue,
-//     listId,
-//     cardId
-//   );
-
-//   board.activities = board.activities || [];
-//   board.activities.unshift(activity);
-
-//   return board;
-// }
-
-// function _createActivity(
-//   boardId,
-//   key,
-//   value,
-//   prevValue,
-//   listId = null,
-//   cardId = null
-// ) {
-//   return {
-//     id: makeId(),
-//     type: "activity",
-//     createdAt: Date.now(),
-//     board: boardId,
-//     list: listId,
-//     card: cardId,
-//     key,
-//     value,
-//     prevValue,
-//   };
-// }
 
 export async function save(board) {
   try {

--- a/src/services/board/board-service-local.js
+++ b/src/services/board/board-service-local.js
@@ -23,6 +23,7 @@ export const boardService = {
   copyList,
   moveAllCards,
   createNewList,
+  createNewListAndMoveAllCards,
 };
 window.bs = boardService;
 
@@ -304,6 +305,35 @@ export function getEmptyList() {
     name: "",
     cards: [],
   };
+}
+
+export async function createNewListAndMoveAllCards(
+  boardId,
+  sourceListId,
+  listName = "New List"
+) {
+  try {
+    const board = await getById(boardId);
+    if (!board) throw new Error("Board not found");
+
+    const sourceList = _findList(board, sourceListId);
+
+    const newList = {
+      ...getEmptyList(),
+      name: listName,
+      cards: [...sourceList.cards],
+    };
+
+    sourceList.cards = [];
+
+    const updatedLists = [...board.lists, newList];
+
+    const updatedBoard = await updateBoard(boardId, { lists: updatedLists });
+    return { newList, updatedLists: updatedBoard.lists };
+  } catch (error) {
+    console.error("Cannot create new list and move cards:", error);
+    throw error;
+  }
 }
 
 function updateBoardFields(board, updates) {

--- a/src/services/board/board-service-local.js
+++ b/src/services/board/board-service-local.js
@@ -280,14 +280,14 @@ export async function moveAllCards(boardId, sourceListId, targetListId) {
   }
 }
 
-export async function createList(boardId, listName = "New List") {
+export async function createList(boardId, listData) {
   try {
     const board = await getById(boardId);
     if (!board) throw new Error("Board not found");
 
     const newList = {
       ...getEmptyList(),
-      name: listName,
+      ...listData,
     };
 
     const updatedLists = [...board.lists, newList];

--- a/src/store/actions/board-actions.js
+++ b/src/store/actions/board-actions.js
@@ -117,6 +117,20 @@ export async function moveAllCardsToList(boardId, sourceListId, targetListId) {
   }
 }
 
+export async function createNewListAndMoveAllCards(boardId, sourceListId, listName = "New List") {
+  try {
+    const { updatedLists } = await boardService.createNewListAndMoveAllCards(
+      boardId,
+      sourceListId,
+      listName
+    );
+    store.dispatch(moveAllCardsAction(updatedLists));
+  } catch (error) {
+    store.dispatch(setError(`Error creating list and moving cards: ${error.message}`));
+    throw error;
+  }
+}
+
 export async function addCard(boardId, card, listId) {
   try {
     const newCard = await boardService.addCard(boardId, card, listId);

--- a/src/store/actions/board-actions.js
+++ b/src/store/actions/board-actions.js
@@ -21,25 +21,29 @@ import { boardService } from "../../services/board";
 
 export async function loadBoards() {
   try {
-    store.dispatch(setLoading(true));
+    store.dispatch(setLoading("loadBoards", true));
     const boards = await boardService.query();
     store.dispatch(setBoards(boards));
   } catch (error) {
-    store.dispatch(setError(`Error loading boards: ${error.message}`));
+    store.dispatch(
+      setError("loadBoards", `Error loading boards: ${error.message}`)
+    );
   } finally {
-    store.dispatch(setLoading(false));
+    store.dispatch(setLoading("loadBoards", false));
   }
 }
 
 export async function loadBoard(boardId, filterBy = {}) {
   try {
-    store.dispatch(setLoading(true));
+    store.dispatch(setLoading("loadBoard", true));
     const board = await boardService.getById(boardId, filterBy);
     store.dispatch(setBoard(board));
   } catch (error) {
-    store.dispatch(setError(`Error loading board: ${error.message}`));
+    store.dispatch(
+      setError("loadBoard", `Error loading board: ${error.message}`)
+    );
   } finally {
-    store.dispatch(setLoading(false));
+    store.dispatch(setLoading("loadBoard", false));
   }
 }
 
@@ -49,7 +53,9 @@ export async function createBoard(board) {
     store.dispatch(addBoard(newBoard));
     return newBoard;
   } catch (error) {
-    store.dispatch(setError(`Error creating board: ${error.message}`));
+    store.dispatch(
+      setError("createBoard", `Error creating board: ${error.message}`)
+    );
     throw error;
   }
 }
@@ -67,7 +73,9 @@ export async function updateBoard(
     store.dispatch(editBoard(updatedBoard));
     return updatedBoard;
   } catch (error) {
-    store.dispatch(setError(`Error updating board: ${error.message}`));
+    store.dispatch(
+      setError("updateBoard", `Error updating board: ${error.message}`)
+    );
     throw error;
   }
 }
@@ -77,7 +85,9 @@ export async function deleteBoard(boardId) {
     await boardService.remove(boardId);
     store.dispatch(deleteBoardAction(boardId));
   } catch (error) {
-    store.dispatch(setError(`Error removing board: ${error.message}`));
+    store.dispatch(
+      setError("deleteBoard", `Error removing board: ${error.message}`)
+    );
     throw error;
   }
 }
@@ -87,7 +97,9 @@ export async function copyList(boardId, listId, newName) {
     const updatedLists = await boardService.copyList(boardId, listId, newName);
     updateBoard(boardId, { lists: updatedLists });
   } catch (error) {
-    store.dispatch(setError(`Error copying list: ${error.message}`));
+    store.dispatch(
+      setError("copyList", `Error copying list: ${error.message}`)
+    );
     throw error;
   }
 }
@@ -130,7 +142,7 @@ export async function addCard(boardId, card, listId) {
     const newCard = await boardService.addCard(boardId, card, listId);
     store.dispatch(addCardAction(newCard, listId));
   } catch (error) {
-    store.dispatch(setError(`Error adding card: ${error.message}`));
+    store.dispatch(setError("addCard", `Error adding card: ${error.message}`));
     throw error;
   }
 }
@@ -140,7 +152,9 @@ export async function editCard(boardId, card, listId) {
     const updatedCard = await boardService.editCard(boardId, card, listId);
     store.dispatch(editCardAction(updatedCard, listId));
   } catch (error) {
-    store.dispatch(setError(`Error editing card: ${error.message}`));
+    store.dispatch(
+      setError("editCard", `Error editing card: ${error.message}`)
+    );
     throw error;
   }
 }
@@ -150,7 +164,9 @@ export async function deleteCard(boardId, cardId, listId) {
     const deletedCard = await boardService.deleteCard(boardId, cardId, listId);
     store.dispatch(deleteCardAction(deletedCard.id, listId));
   } catch (error) {
-    store.dispatch(setError(`Error deleting card: ${error.message}`));
+    store.dispatch(
+      setError("deleteCard", `Error deleting card: ${error.message}`)
+    );
     throw error;
   }
 }
@@ -185,7 +201,7 @@ export async function moveList(
     store.dispatch(moveListAction(updatedLists));
     return updatedLists;
   } catch (error) {
-    store.dispatch(setError(`Error moving list: ${error.message}`));
+    store.dispatch(setError("moveList", `Error moving list: ${error.message}`));
     throw error;
   }
 }
@@ -210,12 +226,12 @@ export function setBoard(board) {
   return { type: SET_BOARD, payload: board };
 }
 
-export function setLoading(isLoading) {
-  return { type: SET_LOADING, payload: isLoading };
+export function setLoading(key, isLoading) {
+  return { type: SET_LOADING, payload: { key, isLoading } };
 }
 
-export function setError(error) {
-  return { type: SET_ERROR, payload: error };
+export function setError(key, error) {
+  return { type: SET_ERROR, payload: { key, error } };
 }
 
 export function setFilters(filterBy) {

--- a/src/store/actions/board-actions.js
+++ b/src/store/actions/board-actions.js
@@ -92,9 +92,9 @@ export async function copyList(boardId, listId, newName) {
   }
 }
 
-export async function createNewList(boardId, listName = "New List") {
+export async function createList(boardId, listName = "New List") {
   try {
-    const newList = await boardService.createNewList(boardId, listName);
+    const newList = await boardService.createList(boardId, listName);
     store.dispatch(addListAction(newList));
     return newList;
   } catch (error) {
@@ -117,16 +117,22 @@ export async function moveAllCardsToList(boardId, sourceListId, targetListId) {
   }
 }
 
-export async function createNewListAndMoveAllCards(boardId, sourceListId, listName = "New List") {
+export async function createListAndMoveAllCards(
+  boardId,
+  sourceListId,
+  listName = "New List"
+) {
   try {
-    const { updatedLists } = await boardService.createNewListAndMoveAllCards(
+    const { updatedLists } = await boardService.createListAndMoveAllCards(
       boardId,
       sourceListId,
       listName
     );
     store.dispatch(moveAllCardsAction(updatedLists));
   } catch (error) {
-    store.dispatch(setError(`Error creating list and moving cards: ${error.message}`));
+    store.dispatch(
+      setError(`Error creating list and moving cards: ${error.message}`)
+    );
     throw error;
   }
 }

--- a/src/store/actions/board-actions.js
+++ b/src/store/actions/board-actions.js
@@ -92,9 +92,9 @@ export async function copyList(boardId, listId, newName) {
   }
 }
 
-export async function createList(boardId, listName = "New List") {
+export async function createList(boardId, listData) {
   try {
-    const newList = await boardService.createList(boardId, listName);
+    const newList = await boardService.createList(boardId, listData);
     store.dispatch(addListAction(newList));
     return newList;
   } catch (error) {

--- a/src/store/actions/board-actions.js
+++ b/src/store/actions/board-actions.js
@@ -94,25 +94,27 @@ export async function copyList(boardId, listId, newName) {
 
 export async function createList(boardId, listData) {
   try {
+    store.dispatch({ type: ADD_LIST.REQUEST });
     const newList = await boardService.createList(boardId, listData);
-    store.dispatch(addListAction(newList));
+    store.dispatch({ type: ADD_LIST.SUCCESS, payload: newList });
     return newList;
   } catch (error) {
-    store.dispatch(setError(`Error creating new list: ${error.message}`));
+    store.dispatch({ type: ADD_LIST.FAILURE, payload: error.message });
     throw error;
   }
 }
 
 export async function moveAllCardsToList(boardId, sourceListId, targetListId) {
   try {
+    store.dispatch({ type: MOVE_ALL_CARDS.REQUEST });
     const updatedLists = await boardService.moveAllCards(
       boardId,
       sourceListId,
       targetListId
     );
-    store.dispatch(moveAllCardsAction(updatedLists));
+    store.dispatch({ type: MOVE_ALL_CARDS.SUCCESS, payload: updatedLists });
   } catch (error) {
-    store.dispatch(setError(`Error moving all cards: ${error.message}`));
+    store.dispatch({ type: MOVE_ALL_CARDS.FAILURE, payload: error.message });
     throw error;
   }
 }
@@ -123,16 +125,15 @@ export async function createListAndMoveAllCards(
   listName = "New List"
 ) {
   try {
+    store.dispatch({ type: MOVE_ALL_CARDS.REQUEST });
     const { updatedLists } = await boardService.createListAndMoveAllCards(
       boardId,
       sourceListId,
       listName
     );
-    store.dispatch(moveAllCardsAction(updatedLists));
+    store.dispatch({ type: MOVE_ALL_CARDS.SUCCESS, payload: updatedLists });
   } catch (error) {
-    store.dispatch(
-      setError(`Error creating list and moving cards: ${error.message}`)
-    );
+    store.dispatch({ type: MOVE_ALL_CARDS.FAILURE, payload: error.message });
     throw error;
   }
 }
@@ -240,12 +241,4 @@ export function clearAllFilters() {
 
 export function moveListAction(lists) {
   return { type: MOVE_LIST, payload: lists };
-}
-
-export function addListAction(list) {
-  return { type: ADD_LIST, payload: list };
-}
-
-export function moveAllCardsAction(updatedLists) {
-  return { type: MOVE_ALL_CARDS, payload: updatedLists };
 }

--- a/src/store/actions/board-actions.js
+++ b/src/store/actions/board-actions.js
@@ -9,6 +9,8 @@ import {
   SET_ERROR,
   SET_FILTERS,
   CLEAR_ALL_FILTERS,
+  ADD_LIST,
+  MOVE_ALL_CARDS,
   ADD_CARD,
   EDIT_CARD,
   DELETE_CARD,
@@ -86,6 +88,31 @@ export async function copyList(boardId, listId, newName) {
     updateBoard(boardId, { lists: updatedLists });
   } catch (error) {
     store.dispatch(setError(`Error copying list: ${error.message}`));
+    throw error;
+  }
+}
+
+export async function createNewList(boardId, listName = "New List") {
+  try {
+    const newList = await boardService.createNewList(boardId, listName);
+    store.dispatch(addListAction(newList));
+    return newList;
+  } catch (error) {
+    store.dispatch(setError(`Error creating new list: ${error.message}`));
+    throw error;
+  }
+}
+
+export async function moveAllCardsToList(boardId, sourceListId, targetListId) {
+  try {
+    const updatedLists = await boardService.moveAllCards(
+      boardId,
+      sourceListId,
+      targetListId
+    );
+    store.dispatch(moveAllCardsAction(updatedLists));
+  } catch (error) {
+    store.dispatch(setError(`Error moving all cards: ${error.message}`));
     throw error;
   }
 }
@@ -193,4 +220,12 @@ export function clearAllFilters() {
 
 export function moveListAction(lists) {
   return { type: MOVE_LIST, payload: lists };
+}
+
+export function addListAction(list) {
+  return { type: ADD_LIST, payload: list };
+}
+
+export function moveAllCardsAction(updatedLists) {
+  return { type: MOVE_ALL_CARDS, payload: updatedLists };
 }

--- a/src/store/actions/board-actions.js
+++ b/src/store/actions/board-actions.js
@@ -104,13 +104,19 @@ export async function createList(boardId, listData) {
   }
 }
 
-export async function moveAllCardsToList(boardId, sourceListId, targetListId) {
+export async function moveAllCards(
+  boardId,
+  sourceListId,
+  targetListId = null,
+  { newListName = "New List" } = {}
+) {
   try {
     store.dispatch({ type: MOVE_ALL_CARDS.REQUEST });
     const updatedLists = await boardService.moveAllCards(
       boardId,
       sourceListId,
-      targetListId
+      targetListId,
+      { newListName }
     );
     store.dispatch({ type: MOVE_ALL_CARDS.SUCCESS, payload: updatedLists });
   } catch (error) {
@@ -126,10 +132,11 @@ export async function createListAndMoveAllCards(
 ) {
   try {
     store.dispatch({ type: MOVE_ALL_CARDS.REQUEST });
-    const { updatedLists } = await boardService.createListAndMoveAllCards(
+    const updatedLists = await boardService.moveAllCards(
       boardId,
       sourceListId,
-      listName
+      null,
+      { newListName: listName }
     );
     store.dispatch({ type: MOVE_ALL_CARDS.SUCCESS, payload: updatedLists });
   } catch (error) {

--- a/src/store/actions/board-actions.js
+++ b/src/store/actions/board-actions.js
@@ -125,26 +125,6 @@ export async function moveAllCards(
   }
 }
 
-export async function createListAndMoveAllCards(
-  boardId,
-  sourceListId,
-  listName = "New List"
-) {
-  try {
-    store.dispatch({ type: MOVE_ALL_CARDS.REQUEST });
-    const updatedLists = await boardService.moveAllCards(
-      boardId,
-      sourceListId,
-      null,
-      { newListName: listName }
-    );
-    store.dispatch({ type: MOVE_ALL_CARDS.SUCCESS, payload: updatedLists });
-  } catch (error) {
-    store.dispatch({ type: MOVE_ALL_CARDS.FAILURE, payload: error.message });
-    throw error;
-  }
-}
-
 export async function addCard(boardId, card, listId) {
   try {
     const newCard = await boardService.addCard(boardId, card, listId);

--- a/src/store/reducers/board-reducer.js
+++ b/src/store/reducers/board-reducer.js
@@ -5,8 +5,12 @@ export const SET_BOARD = "SET_BOARD";
 export const DELETE_BOARD = "DELETE_BOARD";
 export const ADD_BOARD = "ADD_BOARD";
 export const UPDATE_BOARD = "UPDATE_BOARD";
-export const ADD_LIST = "ADD_LIST";
-export const MOVE_ALL_CARDS = "MOVE_ALL_CARDS";
+export const ADD_LIST_REQUEST = "ADD_LIST_REQUEST";
+export const ADD_LIST_SUCCESS = "ADD_LIST_SUCCESS";
+export const ADD_LIST_FAILURE = "ADD_LIST_FAILURE";
+export const MOVE_ALL_CARDS_REQUEST = "MOVE_ALL_CARDS_REQUEST";
+export const MOVE_ALL_CARDS_SUCCESS = "MOVE_ALL_CARDS_SUCCESS";
+export const MOVE_ALL_CARDS_FAILURE = "MOVE_ALL_CARDS_FAILURE";
 export const ADD_CARD = "ADD_CARD";
 export const EDIT_CARD = "EDIT_CARD";
 export const DELETE_CARD = "DELETE_CARD";
@@ -45,22 +49,34 @@ export function boardReducer(state = initialState, action) {
           lists: action.payload,
         },
       };
-    case ADD_LIST:
+    case ADD_LIST_REQUEST:
+      return { ...state, isLoading: true };
+    case ADD_LIST_SUCCESS:
       return {
         ...state,
         board: {
           ...state.board,
           lists: [...state.board.lists, action.payload],
         },
+        isLoading: false,
+        error: null,
       };
-    case MOVE_ALL_CARDS:
+    case ADD_LIST_FAILURE:
+      return { ...state, isLoading: false, error: action.payload };
+    case MOVE_ALL_CARDS_REQUEST:
+      return { ...state, isLoading: true };
+    case MOVE_ALL_CARDS_SUCCESS:
       return {
         ...state,
         board: {
           ...state.board,
           lists: action.payload,
         },
+        isLoading: false,
+        error: null,
       };
+    case MOVE_ALL_CARDS_FAILURE:
+      return { ...state, isLoading: false, error: action.payload };
     case ADD_CARD:
       return {
         ...state,

--- a/src/store/reducers/board-reducer.js
+++ b/src/store/reducers/board-reducer.js
@@ -26,19 +26,19 @@ const initialState = {
 };
 
 const handlers = {
-  ...createAsyncHandlers(ADD_LIST, "addList"),
+  ...createAsyncHandlers(ADD_LIST, ADD_LIST.KEY),
   [ADD_LIST.SUCCESS]: (state, action) => ({
     ...state,
-    loading: { ...state.loading, addList: false },
+    loading: { ...state.loading, [ADD_LIST.KEY]: false },
     board: {
       ...state.board,
       lists: [...state.board.lists, action.payload],
     },
   }),
-  ...createAsyncHandlers(MOVE_ALL_CARDS, "moveAllCards"),
+  ...createAsyncHandlers(MOVE_ALL_CARDS, MOVE_ALL_CARDS.KEY),
   [MOVE_ALL_CARDS.SUCCESS]: (state, action) => ({
     ...state,
-    loading: { ...state.loading, moveAllCards: false },
+    loading: { ...state.loading, [MOVE_ALL_CARDS.KEY]: false },
     board: {
       ...state.board,
       lists: action.payload,

--- a/src/store/reducers/board-reducer.js
+++ b/src/store/reducers/board-reducer.js
@@ -5,6 +5,8 @@ export const SET_BOARD = "SET_BOARD";
 export const DELETE_BOARD = "DELETE_BOARD";
 export const ADD_BOARD = "ADD_BOARD";
 export const UPDATE_BOARD = "UPDATE_BOARD";
+export const ADD_LIST = "ADD_LIST";
+export const MOVE_ALL_CARDS = "MOVE_ALL_CARDS";
 export const ADD_CARD = "ADD_CARD";
 export const EDIT_CARD = "EDIT_CARD";
 export const DELETE_CARD = "DELETE_CARD";
@@ -36,6 +38,22 @@ export function boardReducer(state = initialState, action) {
     case UPDATE_BOARD:
       return { ...state, board: action.payload };
     case MOVE_LIST:
+      return {
+        ...state,
+        board: {
+          ...state.board,
+          lists: action.payload,
+        },
+      };
+    case ADD_LIST:
+      return {
+        ...state,
+        board: {
+          ...state.board,
+          lists: [...state.board.lists, action.payload],
+        },
+      };
+    case MOVE_ALL_CARDS:
       return {
         ...state,
         board: {

--- a/src/store/reducers/board-reducer.js
+++ b/src/store/reducers/board-reducer.js
@@ -116,11 +116,17 @@ const handlers = {
   }),
   [SET_LOADING]: (state, action) => ({
     ...state,
-    loading: { ...state.loading, global: action.payload },
+    loading: {
+      ...state.loading,
+      [action.payload.key]: action.payload.isLoading,
+    },
   }),
   [SET_ERROR]: (state, action) => ({
     ...state,
-    errors: { ...state.errors, global: action.payload },
+    errors: {
+      ...state.errors,
+      [action.payload.key]: action.payload.error,
+    },
   }),
   [SET_FILTERS]: (state, action) => ({
     ...state,

--- a/src/store/reducers/board-reducer.js
+++ b/src/store/reducers/board-reducer.js
@@ -1,13 +1,5 @@
 import { getDefaultFilter } from "../../services/filter-service";
 
-function createAsyncActionTypes(baseType) {
-  return {
-    REQUEST: `${baseType}_REQUEST`,
-    SUCCESS: `${baseType}_SUCCESS`,
-    FAILURE: `${baseType}_FAILURE`,
-  };
-}
-
 export const SET_BOARDS = "SET_BOARDS";
 export const SET_BOARD = "SET_BOARD";
 export const DELETE_BOARD = "DELETE_BOARD";

--- a/src/store/reducers/board-reducer.js
+++ b/src/store/reducers/board-reducer.js
@@ -1,16 +1,20 @@
 import { getDefaultFilter } from "../../services/filter-service";
 
+function createAsyncActionTypes(baseType) {
+  return {
+    REQUEST: `${baseType}_REQUEST`,
+    SUCCESS: `${baseType}_SUCCESS`,
+    FAILURE: `${baseType}_FAILURE`,
+  };
+}
+
 export const SET_BOARDS = "SET_BOARDS";
 export const SET_BOARD = "SET_BOARD";
 export const DELETE_BOARD = "DELETE_BOARD";
 export const ADD_BOARD = "ADD_BOARD";
 export const UPDATE_BOARD = "UPDATE_BOARD";
-export const ADD_LIST_REQUEST = "ADD_LIST_REQUEST";
-export const ADD_LIST_SUCCESS = "ADD_LIST_SUCCESS";
-export const ADD_LIST_FAILURE = "ADD_LIST_FAILURE";
-export const MOVE_ALL_CARDS_REQUEST = "MOVE_ALL_CARDS_REQUEST";
-export const MOVE_ALL_CARDS_SUCCESS = "MOVE_ALL_CARDS_SUCCESS";
-export const MOVE_ALL_CARDS_FAILURE = "MOVE_ALL_CARDS_FAILURE";
+export const ADD_LIST = createAsyncActionTypes("ADD_LIST");
+export const MOVE_ALL_CARDS = createAsyncActionTypes("MOVE_ALL_CARDS");
 export const ADD_CARD = "ADD_CARD";
 export const EDIT_CARD = "EDIT_CARD";
 export const DELETE_CARD = "DELETE_CARD";
@@ -49,9 +53,9 @@ export function boardReducer(state = initialState, action) {
           lists: action.payload,
         },
       };
-    case ADD_LIST_REQUEST:
+    case ADD_LIST.REQUEST:
       return { ...state, isLoading: true };
-    case ADD_LIST_SUCCESS:
+    case ADD_LIST.SUCCESS:
       return {
         ...state,
         board: {
@@ -61,11 +65,11 @@ export function boardReducer(state = initialState, action) {
         isLoading: false,
         error: null,
       };
-    case ADD_LIST_FAILURE:
+    case ADD_LIST.FAILURE:
       return { ...state, isLoading: false, error: action.payload };
-    case MOVE_ALL_CARDS_REQUEST:
+    case MOVE_ALL_CARDS.REQUEST:
       return { ...state, isLoading: true };
-    case MOVE_ALL_CARDS_SUCCESS:
+    case MOVE_ALL_CARDS.SUCCESS:
       return {
         ...state,
         board: {
@@ -75,7 +79,7 @@ export function boardReducer(state = initialState, action) {
         isLoading: false,
         error: null,
       };
-    case MOVE_ALL_CARDS_FAILURE:
+    case MOVE_ALL_CARDS.FAILURE:
       return { ...state, isLoading: false, error: action.payload };
     case ADD_CARD:
       return {

--- a/src/store/reducers/board-reducer.js
+++ b/src/store/reducers/board-reducer.js
@@ -1,4 +1,5 @@
 import { getDefaultFilter } from "../../services/filter-service";
+import { createAsyncActionTypes, createAsyncHandlers } from "../utils";
 
 export const SET_BOARDS = "SET_BOARDS";
 export const SET_BOARD = "SET_BOARD";
@@ -19,123 +20,119 @@ export const CLEAR_ALL_FILTERS = "boards/CLEAR_ALL_FILTERS";
 const initialState = {
   boards: [],
   board: null,
-  isLoading: false,
-  error: null,
+  loading: {},
+  errors: {},
   filterBy: getDefaultFilter(),
 };
 
+const handlers = {
+  ...createAsyncHandlers(ADD_LIST, "addList"),
+  [ADD_LIST.SUCCESS]: (state, action) => ({
+    ...state,
+    loading: { ...state.loading, addList: false },
+    board: {
+      ...state.board,
+      lists: [...state.board.lists, action.payload],
+    },
+  }),
+  ...createAsyncHandlers(MOVE_ALL_CARDS, "moveAllCards"),
+  [MOVE_ALL_CARDS.SUCCESS]: (state, action) => ({
+    ...state,
+    loading: { ...state.loading, moveAllCards: false },
+    board: {
+      ...state.board,
+      lists: action.payload,
+    },
+  }),
+  [SET_BOARDS]: (state, action) => ({
+    ...state,
+    boards: action.payload,
+  }),
+  [SET_BOARD]: (state, action) => ({
+    ...state,
+    board: action.payload,
+  }),
+  [DELETE_BOARD]: (state, action) => {
+    const boards = state.boards.filter(board => board._id !== action.payload);
+    return { ...state, boards };
+  },
+  [ADD_BOARD]: (state, action) => ({
+    ...state,
+    boards: [...state.boards, action.payload],
+  }),
+  [UPDATE_BOARD]: (state, action) => ({
+    ...state,
+    board: action.payload,
+  }),
+  [MOVE_LIST]: (state, action) => ({
+    ...state,
+    board: {
+      ...state.board,
+      lists: action.payload,
+    },
+  }),
+  [ADD_CARD]: (state, action) => ({
+    ...state,
+    board: {
+      ...state.board,
+      lists: state.board.lists.map(list =>
+        list.id === action.payload.listId
+          ? { ...list, cards: [...list.cards, action.payload.card] }
+          : list
+      ),
+    },
+  }),
+  [EDIT_CARD]: (state, action) => ({
+    ...state,
+    board: {
+      ...state.board,
+      lists: state.board.lists.map(list =>
+        list.id === action.payload.listId
+          ? {
+              ...list,
+              cards: list.cards.map(card =>
+                card.id === action.payload.card.id ? action.payload.card : card
+              ),
+            }
+          : list
+      ),
+    },
+  }),
+  [DELETE_CARD]: (state, action) => ({
+    ...state,
+    board: {
+      ...state.board,
+      lists: state.board.lists.map(list =>
+        list.id === action.payload.listId
+          ? {
+              ...list,
+              cards: list.cards.filter(
+                card => card.id !== action.payload.cardId
+              ),
+            }
+          : list
+      ),
+    },
+  }),
+  [SET_LOADING]: (state, action) => ({
+    ...state,
+    loading: { ...state.loading, global: action.payload },
+  }),
+  [SET_ERROR]: (state, action) => ({
+    ...state,
+    errors: { ...state.errors, global: action.payload },
+  }),
+  [SET_FILTERS]: (state, action) => ({
+    ...state,
+    filterBy: { ...state.filterBy, ...action.payload },
+  }),
+  [CLEAR_ALL_FILTERS]: state => ({
+    ...state,
+    filterBy: getDefaultFilter(),
+  }),
+};
+
 export function boardReducer(state = initialState, action) {
-  switch (action.type) {
-    case SET_BOARDS:
-      return { ...state, boards: action.payload };
-    case SET_BOARD:
-      return { ...state, board: action.payload };
-    case DELETE_BOARD:
-      const boards = state.boards.filter(board => board._id !== action.payload);
-      return { ...state, boards };
-    case ADD_BOARD:
-      return { ...state, boards: [...state.boards, action.payload] };
-    case UPDATE_BOARD:
-      return { ...state, board: action.payload };
-    case MOVE_LIST:
-      return {
-        ...state,
-        board: {
-          ...state.board,
-          lists: action.payload,
-        },
-      };
-    case ADD_LIST.REQUEST:
-      return { ...state, isLoading: true };
-    case ADD_LIST.SUCCESS:
-      return {
-        ...state,
-        board: {
-          ...state.board,
-          lists: [...state.board.lists, action.payload],
-        },
-        isLoading: false,
-        error: null,
-      };
-    case ADD_LIST.FAILURE:
-      return { ...state, isLoading: false, error: action.payload };
-    case MOVE_ALL_CARDS.REQUEST:
-      return { ...state, isLoading: true };
-    case MOVE_ALL_CARDS.SUCCESS:
-      return {
-        ...state,
-        board: {
-          ...state.board,
-          lists: action.payload,
-        },
-        isLoading: false,
-        error: null,
-      };
-    case MOVE_ALL_CARDS.FAILURE:
-      return { ...state, isLoading: false, error: action.payload };
-    case ADD_CARD:
-      return {
-        ...state,
-        board: {
-          ...state.board,
-          lists: state.board.lists.map(list =>
-            list.id === action.payload.listId
-              ? { ...list, cards: [...list.cards, action.payload.card] }
-              : list
-          ),
-        },
-      };
-    case EDIT_CARD:
-      return {
-        ...state,
-        board: {
-          ...state.board,
-          lists: state.board.lists.map(list =>
-            list.id === action.payload.listId
-              ? {
-                  ...list,
-                  cards: list.cards.map(card =>
-                    card.id === action.payload.card.id
-                      ? action.payload.card
-                      : card
-                  ),
-                }
-              : list
-          ),
-        },
-      };
-    case DELETE_CARD:
-      return {
-        ...state,
-        board: {
-          ...state.board,
-          lists: state.board.lists.map(list =>
-            list.id === action.payload.listId
-              ? {
-                  ...list,
-                  cards: list.cards.filter(
-                    card => card.id !== action.payload.cardId
-                  ),
-                }
-              : list
-          ),
-        },
-      };
-    case SET_LOADING:
-      return { ...state, isLoading: action.payload };
-    case SET_ERROR:
-      return { ...state, error: action.payload };
-    case SET_FILTERS:
-      return {
-        ...state,
-        filterBy: { ...state.filterBy, ...action.payload },
-      };
-    case CLEAR_ALL_FILTERS:
-      return {
-        ...state,
-        filterBy: getDefaultFilter(),
-      };
-    default:
-      return state;
-  }
+  const handler = handlers[action.type];
+  return handler ? handler(state, action) : state;
 }

--- a/src/store/utils.js
+++ b/src/store/utils.js
@@ -1,3 +1,27 @@
+/**
+ * Creates async action type constants for Redux async actions.
+ * Generates REQUEST, SUCCESS, FAILURE action types and a camelCase KEY.
+ *
+ * @param {string} base - The base action name in SCREAMING_SNAKE_CASE (e.g., "ADD_LIST")
+ * @returns {{REQUEST: string, SUCCESS: string, FAILURE: string, KEY: string}}
+ *   Object containing action type strings and a camelCase key
+ *
+ * @example
+ * const ADD_LIST = createAsyncActionTypes("ADD_LIST");
+ * // Returns:
+ * // {
+ * //   REQUEST: "ADD_LIST_REQUEST",
+ * //   SUCCESS: "ADD_LIST_SUCCESS",
+ * //   FAILURE: "ADD_LIST_FAILURE",
+ * //   KEY: "addList"
+ * // }
+ *
+ * // Usage in reducer:
+ * [ADD_LIST.REQUEST]: (state) => ({ ...state, loading: true })
+ *
+ * // Usage with createAsyncHandlers:
+ * createAsyncHandlers(ADD_LIST, ADD_LIST.KEY)
+ */
 export function createAsyncActionTypes(base) {
   // BASE_ACTION -> baseAction
   const key = base
@@ -14,6 +38,34 @@ export function createAsyncActionTypes(base) {
   };
 }
 
+/**
+ * Creates reducer handlers for async action lifecycle (REQUEST, SUCCESS, FAILURE).
+ * Automatically manages loading and error states in the Redux store.
+ *
+ * @param {{REQUEST: string, SUCCESS: string, FAILURE: string}} actionTypes
+ *   Action types object created by createAsyncActionTypes
+ * @param {string} key - The key to use for tracking loading/error state (e.g., "addList")
+ * @returns {Object.<string, Function>} Object mapping action types to reducer functions
+ *
+ * @example
+ * const ADD_LIST = createAsyncActionTypes("ADD_LIST");
+ *
+ * const handlers = {
+ *   ...createAsyncHandlers(ADD_LIST, ADD_LIST.KEY),
+ *   // Override SUCCESS to add custom logic
+ *   [ADD_LIST.SUCCESS]: (state, action) => ({
+ *     ...state,
+ *     loading: { ...state.loading, [ADD_LIST.KEY]: false },
+ *     items: [...state.items, action.payload],
+ *   }),
+ * };
+ *
+ * // State shape:
+ * // {
+ * //   loading: { addList: true/false },
+ * //   errors: { addList: null | errorMessage }
+ * // }
+ */
 export function createAsyncHandlers(actionTypes, key) {
   return {
     [actionTypes.REQUEST]: state => ({

--- a/src/store/utils.js
+++ b/src/store/utils.js
@@ -1,22 +1,34 @@
-export const createAsyncActionTypes = base => ({
-  REQUEST: `${base}_REQUEST`,
-  SUCCESS: `${base}_SUCCESS`,
-  FAILURE: `${base}_FAILURE`,
-});
+export function createAsyncActionTypes(base) {
+  // BASE_ACTION -> baseAction
+  const key = base
+    .split("_")
+    .map((w, i) =>
+      i === 0 ? w.toLowerCase() : w[0] + w.slice(1).toLowerCase()
+    )
+    .join("");
+  return {
+    REQUEST: `${base}_REQUEST`,
+    SUCCESS: `${base}_SUCCESS`,
+    FAILURE: `${base}_FAILURE`,
+    KEY: key,
+  };
+}
 
-export const createAsyncHandlers = (actionTypes, key) => ({
-  [actionTypes.REQUEST]: state => ({
-    ...state,
-    loading: { ...state.loading, [key]: true },
-    errors: { ...state.errors, [key]: null },
-  }),
-  [actionTypes.SUCCESS]: state => ({
-    ...state,
-    loading: { ...state.loading, [key]: false },
-  }),
-  [actionTypes.FAILURE]: (state, action) => ({
-    ...state,
-    loading: { ...state.loading, [key]: false },
-    errors: { ...state.errors, [key]: action.payload },
-  }),
-});
+export function createAsyncHandlers(actionTypes, key) {
+  return {
+    [actionTypes.REQUEST]: state => ({
+      ...state,
+      loading: { ...state.loading, [key]: true },
+      errors: { ...state.errors, [key]: null },
+    }),
+    [actionTypes.SUCCESS]: state => ({
+      ...state,
+      loading: { ...state.loading, [key]: false },
+    }),
+    [actionTypes.FAILURE]: (state, action) => ({
+      ...state,
+      loading: { ...state.loading, [key]: false },
+      errors: { ...state.errors, [key]: action.payload },
+    }),
+  };
+}

--- a/src/store/utils.js
+++ b/src/store/utils.js
@@ -1,0 +1,22 @@
+export const createAsyncActionTypes = base => ({
+  REQUEST: `${base}_REQUEST`,
+  SUCCESS: `${base}_SUCCESS`,
+  FAILURE: `${base}_FAILURE`,
+});
+
+export const createAsyncHandlers = (actionTypes, key) => ({
+  [actionTypes.REQUEST]: state => ({
+    ...state,
+    loading: { ...state.loading, [key]: true },
+    errors: { ...state.errors, [key]: null },
+  }),
+  [actionTypes.SUCCESS]: state => ({
+    ...state,
+    loading: { ...state.loading, [key]: false },
+  }),
+  [actionTypes.FAILURE]: (state, action) => ({
+    ...state,
+    loading: { ...state.loading, [key]: false },
+    errors: { ...state.errors, [key]: action.payload },
+  }),
+});


### PR DESCRIPTION
## 🎯 Description

Implements "Move All Cards" feature for lists, allowing users to move all cards to existing lists or create a new "New List". Addresses ticket [CATC-55](https://trello.com/c/H7Qv1wUZ).

## 🔧 Changes

### Core Features

- ✨ Added "Move All Cards" menu option in list actions
- 🔧 Created `moveAllCards` and `createList` service functions
- 🔄 Added Redux actions and reducer cases for `ADD_LIST` and `MOVE_ALL_CARDS`

### Redux Infrastructure

- 🏗️ __Created Redux utilities__: `createAsyncActionTypes` (generates REQUEST/SUCCESS/FAILURE + auto-generated `.KEY`) and `createAsyncHandlers` (manages loading/error states)
- 🔄 __Refactored state management__: Dynamic loading/error keys instead of global flags (`loading.addList`, `errors.moveAllCards`)
- ✅ __Replaced string literals__ with constants for type safety
- 📝 __Added JSDoc documentation__ for utility functions

### Styling

- 🎨 Created reusable `.popover-menu` CSS class for consistent menu styling across the app

## 📝 Notes

- Supports moving to existing lists or creating "New List"
- Source list is emptied after move operation
- Current list disabled in destination menu to prevent self-move
- Granular state tracking enables multiple simultaneous async operations
- Established scalable pattern for future async actions


  ## 🖥️ Demo

  <details>
    <summary>Watch Demo Video</summary>



https://github.com/user-attachments/assets/aa0fd7fd-1920-40be-98f8-ae2f361c70f2

### AFTER CODE REVIEW CHANGES

https://github.com/user-attachments/assets/0d8ce8f5-e330-4307-9cb3-2bef42758713




  </details>