### PR TITLE
feature/CATC_58-implement-archive-this-list-in-list-actions

### DIFF
--- a/src/components/ListActionsMenu.jsx
+++ b/src/components/ListActionsMenu.jsx
@@ -9,7 +9,11 @@ import { Popover } from "./Popover";
 import "../assets/styles/components/ListActionsMenu.css";
 import { CopyListForm } from "./CopyListForm";
 import { MoveListForm } from "./MoveListForm";
-import { moveList, loadBoards } from "../store/actions/board-actions";
+import {
+  moveList,
+  loadBoards,
+  archiveList,
+} from "../store/actions/board-actions";
 
 export function ListActionsMenu({
   list,
@@ -26,7 +30,13 @@ export function ListActionsMenu({
 
   function handleMenuClick(key) {
     if (!listActionsMenuItems().find(item => item.key === key)) return;
-    setActiveAction(key);
+
+    if (key === "archiveList") {
+      archiveList(currentBoard._id, list.id);
+      onClose();
+    } else {
+      setActiveAction(key);
+    }
   }
 
   function handleMoveAllCards(destinationListId) {
@@ -129,7 +139,7 @@ function listActionsMenuItems() {
     { label: "Move All cards in this list", key: "moveAll" },
     { label: "Sort list...", key: "sort" },
     { label: "Watch", key: "watch" },
-    { label: "Archive this list", key: "archive" },
-    { label: "Archive all cards in this list", key: "archiveAll" },
+    { label: "Archive this list", key: "archiveList" },
+    { label: "Archive all cards in this list", key: "archiveAllCards" },
   ];
 }

--- a/src/services/board/board-data-generator.js
+++ b/src/services/board/board-data-generator.js
@@ -128,6 +128,7 @@ export function generateList(
     id: crypto.randomUUID(),
     title: faker.helpers.arrayElement(listNames),
     cards,
+    archivedAt: null,
     ...options,
   };
 

--- a/src/services/board/board-service-local.js
+++ b/src/services/board/board-service-local.js
@@ -27,6 +27,8 @@ export const boardService = {
   editLabel,
   deleteLabel,
   updateCardLabels,
+  archiveList,
+  unarchiveList,
 };
 window.bs = boardService;
 
@@ -325,7 +327,42 @@ export function getEmptyList() {
     id: crypto.randomUUID(),
     title: "",
     cards: [],
+    archivedAt: null,
   };
+}
+
+async function updateListArchiveStatus(boardId, listId, archivedAt) {
+  const board = await getById(boardId);
+  const list = _findList(board, listId);
+
+  if (archivedAt && list.archivedAt) {
+    throw new Error("List is already archived");
+  }
+  if (!archivedAt && !list.archivedAt) {
+    throw new Error("List is not archived");
+  }
+
+  const updatedList = { ...list, archivedAt };
+  await updateBoard(boardId, { archivedAt }, { listId });
+  return updatedList;
+}
+
+export async function archiveList(boardId, listId) {
+  try {
+    return await updateListArchiveStatus(boardId, listId, Date.now());
+  } catch (error) {
+    console.error("Cannot archive list:", error);
+    throw error;
+  }
+}
+
+export async function unarchiveList(boardId, listId) {
+  try {
+    return await updateListArchiveStatus(boardId, listId, null);
+  } catch (error) {
+    console.error("Cannot unarchive list:", error);
+    throw error;
+  }
 }
 
 function updateBoardFields(board, updates) {

--- a/src/services/filter-service.js
+++ b/src/services/filter-service.js
@@ -37,10 +37,12 @@ export function getFilteredBoard(board, filterBy) {
 
   return {
     ...board,
-    lists: board.lists.map(list => ({
-      ...list,
-      cards: filterCards(list.cards, filterBy),
-    })),
+    lists: board.lists
+      .filter(list => !list.archivedAt)
+      .map(list => ({
+        ...list,
+        cards: filterCards(list.cards, filterBy),
+      })),
   };
 }
 

--- a/src/store/actions/board-actions.js
+++ b/src/store/actions/board-actions.js
@@ -18,6 +18,8 @@ import {
   EDIT_LABEL,
   DELETE_LABEL,
   UPDATE_CARD_LABELS,
+  ARCHIVE_LIST,
+  UNARCHIVE_LIST,
 } from "../reducers/board-reducer";
 
 import { store } from "../store";
@@ -266,6 +268,30 @@ export async function updateCardLabels(
       type: UPDATE_CARD_LABELS.FAILURE,
       payload: error.message,
     });
+    throw error;
+  }
+}
+
+export async function archiveList(boardId, listId) {
+  try {
+    store.dispatch({ type: ARCHIVE_LIST.REQUEST });
+    const updatedList = await boardService.archiveList(boardId, listId);
+    store.dispatch({ type: ARCHIVE_LIST.SUCCESS, payload: updatedList });
+    return updatedList;
+  } catch (error) {
+    store.dispatch({ type: ARCHIVE_LIST.FAILURE, payload: error.message });
+    throw error;
+  }
+}
+
+export async function unarchiveList(boardId, listId) {
+  try {
+    store.dispatch({ type: UNARCHIVE_LIST.REQUEST });
+    const updatedList = await boardService.unarchiveList(boardId, listId);
+    store.dispatch({ type: UNARCHIVE_LIST.SUCCESS, payload: updatedList });
+    return updatedList;
+  } catch (error) {
+    store.dispatch({ type: UNARCHIVE_LIST.FAILURE, payload: error.message });
     throw error;
   }
 }

--- a/src/store/actions/board-actions.js
+++ b/src/store/actions/board-actions.js
@@ -24,6 +24,7 @@ import {
 
 import { store } from "../store";
 import { boardService } from "../../services/board";
+import { createAsyncAction } from "../utils";
 
 export async function loadBoards() {
   try {
@@ -272,29 +273,17 @@ export async function updateCardLabels(
   }
 }
 
-export async function archiveList(boardId, listId) {
-  try {
-    store.dispatch({ type: ARCHIVE_LIST.REQUEST });
-    const updatedList = await boardService.archiveList(boardId, listId);
-    store.dispatch({ type: ARCHIVE_LIST.SUCCESS, payload: updatedList });
-    return updatedList;
-  } catch (error) {
-    store.dispatch({ type: ARCHIVE_LIST.FAILURE, payload: error.message });
-    throw error;
-  }
-}
+export const archiveList = createAsyncAction(
+  ARCHIVE_LIST,
+  boardService.archiveList,
+  store
+);
 
-export async function unarchiveList(boardId, listId) {
-  try {
-    store.dispatch({ type: UNARCHIVE_LIST.REQUEST });
-    const updatedList = await boardService.unarchiveList(boardId, listId);
-    store.dispatch({ type: UNARCHIVE_LIST.SUCCESS, payload: updatedList });
-    return updatedList;
-  } catch (error) {
-    store.dispatch({ type: UNARCHIVE_LIST.FAILURE, payload: error.message });
-    throw error;
-  }
-}
+export const unarchiveList = createAsyncAction(
+  UNARCHIVE_LIST,
+  boardService.unarchiveList,
+  store
+);
 
 export function setBoards(boards) {
   return { type: SET_BOARDS, payload: boards };

--- a/src/store/reducers/board-reducer.js
+++ b/src/store/reducers/board-reducer.js
@@ -8,6 +8,8 @@ export const ADD_BOARD = "ADD_BOARD";
 export const UPDATE_BOARD = "UPDATE_BOARD";
 export const ADD_LIST = createAsyncActionTypes("ADD_LIST");
 export const MOVE_ALL_CARDS = createAsyncActionTypes("MOVE_ALL_CARDS");
+export const ARCHIVE_LIST = createAsyncActionTypes("ARCHIVE_LIST");
+export const UNARCHIVE_LIST = createAsyncActionTypes("UNARCHIVE_LIST");
 export const ADD_CARD = "ADD_CARD";
 export const EDIT_CARD = "EDIT_CARD";
 export const DELETE_CARD = "DELETE_CARD";
@@ -47,6 +49,28 @@ const handlers = {
     board: {
       ...state.board,
       lists: action.payload,
+    },
+  }),
+  ...createAsyncHandlers(ARCHIVE_LIST, ARCHIVE_LIST.KEY),
+  [ARCHIVE_LIST.SUCCESS]: (state, action) => ({
+    ...state,
+    loading: { ...state.loading, [ARCHIVE_LIST.KEY]: false },
+    board: {
+      ...state.board,
+      lists: state.board.lists.map(list =>
+        list.id === action.payload.id ? action.payload : list
+      ),
+    },
+  }),
+  ...createAsyncHandlers(UNARCHIVE_LIST, UNARCHIVE_LIST.KEY),
+  [UNARCHIVE_LIST.SUCCESS]: (state, action) => ({
+    ...state,
+    loading: { ...state.loading, [UNARCHIVE_LIST.KEY]: false },
+    board: {
+      ...state.board,
+      lists: state.board.lists.map(list =>
+        list.id === action.payload.id ? action.payload : list
+      ),
     },
   }),
   [SET_BOARDS]: (state, action) => ({

--- a/src/store/reducers/board-reducer.js
+++ b/src/store/reducers/board-reducer.js
@@ -57,22 +57,10 @@ const handlers = {
     loading: { ...state.loading, [ARCHIVE_LIST.KEY]: false },
     board: {
       ...state.board,
-      lists: state.board.lists.map(list =>
-        list.id === action.payload.id ? action.payload : list
-      ),
+      lists: state.board.lists.map(list => list.id !== action.payload.id),
     },
   }),
   ...createAsyncHandlers(UNARCHIVE_LIST, UNARCHIVE_LIST.KEY),
-  [UNARCHIVE_LIST.SUCCESS]: (state, action) => ({
-    ...state,
-    loading: { ...state.loading, [UNARCHIVE_LIST.KEY]: false },
-    board: {
-      ...state.board,
-      lists: state.board.lists.map(list =>
-        list.id === action.payload.id ? action.payload : list
-      ),
-    },
-  }),
   [SET_BOARDS]: (state, action) => ({
     ...state,
     boards: action.payload,

--- a/src/store/reducers/board-reducer.js
+++ b/src/store/reducers/board-reducer.js
@@ -57,7 +57,7 @@ const handlers = {
     loading: { ...state.loading, [ARCHIVE_LIST.KEY]: false },
     board: {
       ...state.board,
-      lists: state.board.lists.map(list => list.id !== action.payload.id),
+      lists: state.board.lists.filter(list => list.id !== action.payload.id),
     },
   }),
   ...createAsyncHandlers(UNARCHIVE_LIST, UNARCHIVE_LIST.KEY),

--- a/src/store/utils.js
+++ b/src/store/utils.js
@@ -84,3 +84,36 @@ export function createAsyncHandlers(actionTypes, key) {
     }),
   };
 }
+
+/**
+ * Creates an async action creator that handles REQUEST, SUCCESS, FAILURE lifecycle.
+ * Eliminates repetitive async action boilerplate code.
+ *
+ * @param {Object} actionTypes - Action types object from createAsyncActionTypes
+ * @param {Function} serviceFunction - The service function to call
+ * @param {Function} store - The Redux store instance for using dispatch
+ * @returns {Function} Async action creator function
+ *
+ * @example
+ * const archiveList = createAsyncAction(
+ *   ARCHIVE_LIST,
+ *   boardService.archiveList,
+ *   store
+ * );
+ *
+ * // Usage:
+ * archiveList(boardId, listId);
+ */
+export function createAsyncAction(actionTypes, serviceFunction, store) {
+  return async (...args) => {
+    try {
+      store.dispatch({ type: actionTypes.REQUEST });
+      const result = await serviceFunction(...args);
+      store.dispatch({ type: actionTypes.SUCCESS, payload: result });
+      return result;
+    } catch (error) {
+      store.dispatch({ type: actionTypes.FAILURE, payload: error.message });
+      throw error;
+    }
+  };
+}


### PR DESCRIPTION
## 🎯 Description
Implement list archival functionality. Users can archive lists through the actions menu, and archived lists are automatically hidden from the board view.

## 🔧 Changes
- 📊 __Data Model__: Added `archivedAt` timestamp to list schema
- 🛠️ __Service__: Implemented `archiveList()` and `unarchiveList` with validation logic
- 🔄 __Redux__: Added `ARCHIVE_LIST` and `UNARCHIVE_LIST` actions and reducers
- 🎯 __Utils__: Created reusable `createAsyncAction()` utility
- 👀 __Filtering__: Enhanced `getFilteredBoard()` to hide archived lists

## 📝 Notes
- Archived lists preserved in backend but hidden from UI
- Archiving diverges Redux state from the databse state by removing the archived list for the state entirely. This will require future brainstorming when implementing an "unarchive" feature.

## 🖥️ Demo

<details>
  <summary>Watch Demo Video</summary>

  <p align="center">


https://github.com/user-attachments/assets/6dc5fe5e-5e04-4139-bbb1-373e46e4d44d




  </p>

</details>
