### PR TITLE
Bugfix/catc 66 fix title property naming inconsistency

### DIFF
--- a/src/components/AddList.jsx
+++ b/src/components/AddList.jsx
@@ -10,23 +10,23 @@ import { boardService } from "../services/board";
 
 export function AddList({ onAddList }) {
   const [showAddList, setShowAddList] = useState(false);
-  const [newListName, setNewListName] = useState("");
+  const [newListTitle, setNewListTitle] = useState("");
 
   function handleAddList() {
-    if (!newListName) {
+    if (!newListTitle) {
       handleHideAddList();
       return;
     }
 
     const newList = boardService.getEmptyList();
-    newList.name = newListName;
+    newList.title = newListTitle;
     onAddList(newList);
 
-    setNewListName("");
+    setNewListTitle("");
   }
 
   function handleHideAddList() {
-    setNewListName("");
+    setNewListTitle("");
     setShowAddList(false);
   }
 
@@ -46,9 +46,9 @@ export function AddList({ onAddList }) {
             <TextField
               id="outlined-basic"
               variant="outlined"
-              value={newListName}
+              value={newListTitle}
               placeholder="Enter list name"
-              onChange={e => setNewListName(e.target.value)}
+              onChange={e => setNewListTitle(e.target.value)}
               autoFocus
             />
           </div>

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -107,7 +107,7 @@ export function List({
   return (
     <section className="list-container">
       <div className="list-header">
-        <h2>{list.name}</h2>
+        <h2>{list.title}</h2>
         <SquareIconButton
           icon={<MoreHoriz />}
           onClick={handleMoreClick}

--- a/src/components/ListActionsMenu.jsx
+++ b/src/components/ListActionsMenu.jsx
@@ -81,7 +81,7 @@ export function ListActionsMenu({
     >
       {activeAction === "copy" ? (
         <CopyListForm
-          initialValue={list.name}
+          initialValue={list.title}
           onCopy={newName => handleCopyList(list.id, newName)}
           onCancel={handleCopyCancel}
         />
@@ -93,7 +93,7 @@ export function ListActionsMenu({
               disabled={listItem.id === list.id}
               onClick={() => handleMoveAllCards(listItem.id)}
             >
-              <ListItemText>{listItem.name}</ListItemText>
+              <ListItemText>{listItem.title}</ListItemText>
             </MenuItem>
           ))}
           <MenuItem onClick={() => handleMoveAllCards("new")}>

--- a/src/components/MoveListForm.jsx
+++ b/src/components/MoveListForm.jsx
@@ -61,7 +61,7 @@ export function MoveListForm({
           >
             {boards.map(b => (
               <MenuItem key={b._id} value={b._id}>
-                {b.name}
+                {b.title}
               </MenuItem>
             ))}
           </Select>

--- a/src/pages/BoardDetails.jsx
+++ b/src/pages/BoardDetails.jsx
@@ -103,7 +103,7 @@ export function BoardDetails() {
   return (
     <section className="board-container">
       <header className="board-header">
-        <h2 className="board-title">{board.name}</h2>
+        <h2 className="board-title">{board.title}</h2>
         <div className="board-header-right">
           <FilterMenu />
           <button className="icon-button">

--- a/src/pages/BoardDetails.jsx
+++ b/src/pages/BoardDetails.jsx
@@ -69,10 +69,10 @@ export function BoardDetails() {
     try {
       const options = { listId: list.id };
       updateBoard(board._id, updates, options);
-      showSuccessMsg(`The list ${list.name} updated successfully!`);
+      showSuccessMsg(`The list ${list.title} updated successfully!`);
     } catch (error) {
       console.error("List update failed:", error);
-      showErrorMsg(`Unable to update the list: ${list.name}`);
+      showErrorMsg(`Unable to update the list: ${list.title}`);
     }
   }
 

--- a/src/pages/CardDetails.jsx
+++ b/src/pages/CardDetails.jsx
@@ -54,7 +54,7 @@ export function CardDetails() {
     <CardModal
       boardId={boardId}
       listId={list.id}
-      listTitle={list.name}
+      listTitle={list.title}
       card={card}
       cardLabels={cardLabels}
       onEditCard={handleEditCard}

--- a/src/services/board/board-data-generator.js
+++ b/src/services/board/board-data-generator.js
@@ -154,7 +154,7 @@ export function generateBoard(listCount = 3, cardsPerList = 3, options = {}) {
 
   const board = {
     _id: boardId,
-    name: faker.helpers.arrayElement(PROJECT_TYPES),
+    title: faker.helpers.arrayElement(PROJECT_TYPES),
     description: faker.company.catchPhrase() + " - " + faker.lorem.sentence(),
     createdAt,
     updatedAt,
@@ -305,7 +305,7 @@ export function generateBoardWithUsers(
 
   const board = {
     _id: boardId,
-    name: faker.helpers.arrayElement(PROJECT_TYPES),
+    title: faker.helpers.arrayElement(PROJECT_TYPES),
     description: faker.company.catchPhrase() + " - " + faker.lorem.sentence(),
     createdAt,
     updatedAt,
@@ -412,7 +412,7 @@ export function generateSampleData() {
     4,
     4,
     {
-      name: "Sample Development Board",
+      title: "Sample Development Board",
       description: "A comprehensive sample board for development and testing",
       userCount: 6,
     }

--- a/src/services/board/board-data-generator.js
+++ b/src/services/board/board-data-generator.js
@@ -126,7 +126,7 @@ export function generateList(
 
   const list = {
     id: crypto.randomUUID(),
-    name: faker.helpers.arrayElement(listNames),
+    title: faker.helpers.arrayElement(listNames),
     cards,
     ...options,
   };
@@ -444,7 +444,7 @@ export function generateSampleData() {
     sampleList: generateList(
       4,
       {
-        name: "Sample List",
+        title: "Sample List",
       },
       sampleUsers
     ),

--- a/src/services/board/board-service-local.js
+++ b/src/services/board/board-service-local.js
@@ -56,7 +56,7 @@ export async function copyList(boardId, listId, newName) {
     const clonedList = {
       ...listToCopy,
       id: crypto.randomUUID(),
-      name: newName,
+      title: newName,
       cards: clonedCards,
     };
 
@@ -267,7 +267,7 @@ export async function moveAllCards(
   boardId,
   sourceListId,
   targetListId = null,
-  { newListName = "New List" } = {}
+  { newListTitle = "New List" } = {}
 ) {
   try {
     const board = await getById(boardId);
@@ -282,7 +282,7 @@ export async function moveAllCards(
     if (!targetListId) {
       const newList = {
         ...getEmptyList(),
-        name: newListName,
+        title: newListTitle,
         cards: cardsToMove,
       };
       updatedLists = [...board.lists, newList];
@@ -323,7 +323,7 @@ export async function createList(boardId, listData) {
 export function getEmptyList() {
   return {
     id: crypto.randomUUID(),
-    name: "",
+    title: "",
     cards: [],
   };
 }

--- a/src/services/board/index.js
+++ b/src/services/board/index.js
@@ -6,7 +6,7 @@ import boardDataGenerator from "../board/board-data-generator.js";
 function getEmptyBoard() {
   return {
     _id: crypto.randomUUID(),
-    name: "",
+    title: "",
     description: "",
     createdAt: "",
     updatedAt: "",


### PR DESCRIPTION
## 🎯 Description
This PR fixes naming inconsistencies in the board and list entities. 

## 🔧 Changes
- The `name` property in lists and boards were changed to `title` project wide.

## 📝 Notes
- After this is merged, we need to re-create the boards data locally. As I didn't provide a migration plan.
