### PR TITLE
feature/CATC_64-allow-users-to-signup

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,7 +9,8 @@ import { CardDetails } from "./pages/CardDetails";
 import { UserDetails } from "./pages/UserDetails";
 import { ChatApp } from "./pages/Chat";
 import { AdminIndex } from "./pages/AdminIndex";
-import { LoginSignup, Login, Signup } from "./pages/LoginSignup";
+import { Login } from "./pages/LoginSignup";
+import { SignupPage } from "./pages/SignupPage";
 
 export function App() {
   const location = useLocation();
@@ -32,10 +33,8 @@ export function App() {
           <Route path="user/:userId" element={<UserDetails />} />
           <Route path="chat" element={<ChatApp />} />
           <Route path="admin" element={<AdminIndex />} />
-          <Route path="auth" element={<LoginSignup />}>
-            <Route path="login" element={<Login />} />
-            <Route path="signup" element={<Signup />} />
-          </Route>
+          <Route path="signup" element={<SignupPage />} />
+          <Route path="login" element={<Login />} />
         </Routes>
         {backgroundLocation && (
           <Routes>

--- a/src/assets/styles/components/SignupForm.css
+++ b/src/assets/styles/components/SignupForm.css
@@ -1,0 +1,324 @@
+.signup-container {
+  /* Primary Colors */
+  --signup-primary-900: #0747a6;
+  --signup-primary-800: #0052cc;
+  --signup-primary-700: #0065ff;
+  --signup-primary-600: #2684ff;
+  --signup-primary-400: #b3d4ff;
+
+  /* Text Colors */
+  --signup-text-primary: #172b4d;
+  --signup-text-secondary: #44546f;
+  --signup-text-tertiary: #5e6c84;
+  --signup-text-disabled: #8590a2;
+  --signup-text-inverse: #ffffff;
+  --signup-text-link: #0c66e4;
+
+  /* Background Colors */
+  --signup-bg-primary: #ffffff;
+  --signup-bg-secondary: #fafbfc;
+  --signup-bg-tertiary: #f4f5f7;
+
+  /* Border Colors */
+  --signup-border-primary: #c1c7d0;
+  --signup-border-secondary: #8590a2;
+  --signup-border-focus: #388bff;
+  --signup-border-error: #de350b;
+
+  /* Success Colors */
+  --signup-success: #00875a;
+  --signup-success-light: #36b37e;
+
+  /* Typography */
+  --signup-font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", Ubuntu, "Helvetica Neue", sans-serif;
+  --signup-font-size-11: 11px;
+  --signup-font-size-12: 12px;
+  --signup-font-size-14: 14px;
+  --signup-font-size-16: 16px;
+  --signup-font-weight-medium: 500;
+  --signup-font-weight-semibold: 600;
+  --signup-font-weight-bold: 700;
+
+  /* Spacing */
+  --signup-space-050: 4px;
+  --signup-space-075: 6px;
+  --signup-space-100: 8px;
+  --signup-space-150: 12px;
+  --signup-space-200: 16px;
+  --signup-space-300: 24px;
+  --signup-space-400: 32px;
+  --signup-space-500: 40px;
+
+  /* Border Radius */
+  --signup-border-radius: 3px;
+
+  /* Transitions */
+  --signup-transition-fast: 0.1s ease-out;
+
+  /* Layout */
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  background-color: var(--signup-bg-secondary);
+}
+
+.signup-wrapper {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  padding-top: 80px;
+  max-width: 1200px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: var(--signup-space-200);
+  padding-right: var(--signup-space-200);
+}
+
+.signup-card {
+  display: flex;
+  flex-direction: column;
+  margin: 0 auto;
+  width: 400px;
+  max-width: 100%;
+  padding: var(--signup-space-400) var(--signup-space-500);
+  background: var(--signup-bg-primary);
+  border-radius: var(--signup-border-radius);
+  box-shadow: rgba(0, 0, 0, 0.1) 0px 0px 10px;
+  box-sizing: border-box;
+  color: var(--signup-text-secondary);
+}
+
+.signup-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  margin-bottom: var(--signup-space-200);
+}
+
+.signup-title.MuiTypography-root {
+  font-weight: var(--signup-font-weight-semibold);
+  margin: 0;
+  color: var(--signup-text-primary);
+  font-size: var(--signup-font-size-16);
+  text-align: center;
+}
+
+.signup-form-field {
+  margin-top: var(--signup-space-300);
+}
+
+.signup-form-field:first-child {
+  margin-top: 10px;
+}
+
+.signup-form-label.MuiTypography-root {
+  font-size: var(--signup-font-size-12);
+  color: var(--signup-text-tertiary);
+  font-weight: var(--signup-font-weight-semibold);
+  margin-bottom: var(--signup-space-075);
+  display: block;
+}
+
+.signup-text-field .MuiOutlinedInput-root {
+  background-color: var(--signup-bg-secondary);
+  border: 1px solid var(--signup-border-secondary);
+  border-radius: var(--signup-border-radius);
+  font-family: var(--signup-font-family);
+}
+
+.signup-text-field .MuiOutlinedInput-root:hover {
+  border-color: var(--signup-border-secondary);
+}
+
+.signup-text-field .MuiOutlinedInput-root.Mui-focused {
+  border-color: var(--signup-border-focus);
+  background-color: var(--signup-bg-primary);
+}
+
+.signup-text-field .MuiOutlinedInput-input {
+  padding: var(--signup-space-100) var(--signup-space-075);
+  font-size: var(--signup-font-size-14);
+  font-family: var(--signup-font-family);
+}
+
+.signup-text-field .MuiOutlinedInput-notchedOutline {
+  border: none;
+}
+
+.signup-password-toggle {
+  padding: var(--signup-space-050);
+  color: var(--signup-text-tertiary);
+}
+
+.signup-password-strength {
+  margin-top: var(--signup-space-100);
+}
+
+.strength-bars {
+  display: flex;
+  gap: var(--signup-space-050);
+  margin-bottom: var(--signup-space-075);
+}
+
+.strength-bar {
+  flex: 1;
+  height: 4px;
+  background-color: var(--signup-border-primary);
+  border-radius: 2px;
+  transition: background-color var(--signup-transition-fast);
+}
+
+/* Strength text message */
+.strength-text {
+  font-size: var(--signup-font-size-11);
+  color: var(--signup-text-tertiary);
+  text-align: left;
+  margin-top: var(--signup-space-050);
+}
+
+.strength-text-gray {
+  color: var(--signup-text-tertiary);
+}
+
+.strength-text-center {
+  text-align: center;
+}
+
+.strength-bar.strength-weak {
+  background-color: #de350b;
+}
+
+.strength-bar.strength-fair {
+  background-color: #ff5630;
+}
+
+.strength-bar.strength-good {
+  background-color: #ffab00;
+}
+
+.strength-bar.strength-strong {
+  background-color: #36b37e;
+}
+
+.strength-bar.strength-very-strong {
+  background-color: #00875a;
+}
+
+.strength-bar.strength-neutral {
+  background-color: var(--signup-border-primary);
+}
+
+.signup-checkbox .MuiCheckbox-root {
+  color: var(--signup-border-secondary);
+}
+
+.signup-checkbox .MuiCheckbox-root.Mui-checked {
+  color: var(--signup-primary-800);
+}
+
+.signup-checkbox.MuiFormControlLabel-root .MuiFormControlLabel-label {
+  font-size: var(--signup-font-size-12);
+  color: var(--signup-text-tertiary);
+}
+
+.signup-legal-text.MuiTypography-root {
+  font-size: var(--signup-font-size-12);
+  color: var(--signup-text-tertiary);
+  margin-top: var(--signup-space-100);
+  margin-bottom: var(--signup-space-400);
+  margin-left: var(--signup-space-075);
+}
+
+.signup-legal-text a {
+  color: var(--signup-text-link);
+  text-decoration: none;
+}
+
+.signup-continue-button {
+  background: var(--signup-primary-800) !important;
+  color: var(--signup-text-inverse) !important;
+  border-radius: var(--signup-border-radius);
+  font-weight: var(--signup-font-weight-medium);
+  height: var(--signup-space-500);
+  margin-top: 0;
+  text-transform: none;
+  font-family: var(--signup-font-family);
+}
+
+.signup-continue-button:hover {
+  background: var(--signup-primary-700) !important;
+}
+
+.signup-continue-button:disabled {
+  background: var(--signup-primary-400) !important;
+}
+
+.signup-footer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  border-top: 1px solid var(--signup-border-primary);
+  padding-top: var(--signup-space-400);
+  font-size: var(--signup-font-size-11);
+  color: var(--signup-text-primary);
+  margin-top: var(--signup-space-400);
+}
+
+.signup-footer a {
+  color: var(--signup-primary-800);
+  text-decoration: none;
+}
+
+.signup-footer-text.MuiTypography-root {
+  padding-top: var(--signup-space-100);
+  font-size: var(--signup-font-size-11);
+  color: var(--signup-text-primary);
+}
+
+.signup-footer-legal.MuiTypography-root {
+  margin-top: var(--signup-space-200);
+  font-size: var(--signup-font-size-11);
+  color: var(--signup-text-primary);
+}
+
+.signup-login-link.MuiTypography-root {
+  margin-top: var(--signup-space-300);
+  font-size: var(--signup-font-size-14);
+  color: var(--signup-text-tertiary);
+  text-align: center;
+}
+
+.signup-login-link a {
+  color: var(--signup-text-link);
+  text-decoration: none;
+  font-weight: var(--signup-font-weight-medium);
+}
+
+.signup-login-link a:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 768px) {
+  .signup-wrapper {
+    margin: 0;
+    justify-content: flex-start;
+  }
+
+  .signup-card {
+    padding: var(--signup-space-400) var(--signup-space-200);
+    background: transparent;
+    box-shadow: none;
+    width: 320px;
+  }
+}
+
+@media (max-width: 480px) {
+  .signup-card {
+    width: 100%;
+    padding: var(--signup-space-200);
+  }
+}

--- a/src/assets/styles/main.css
+++ b/src/assets/styles/main.css
@@ -35,6 +35,7 @@
 @import "components/MoveListForm";
 @import "components/Card";
 @import "components/FilterMenu";
+@import "components/SignupForm";
 
 @import "components/review/ReviewEdit";
 @import "components/review/ReviewList";

--- a/src/components/SignupForm.jsx
+++ b/src/components/SignupForm.jsx
@@ -1,0 +1,311 @@
+import { useState } from "react";
+import { useForm, Controller, useWatch } from "react-hook-form";
+import { Link as RouterLink } from "react-router-dom";
+import Box from "@mui/material/Box";
+import TextField from "@mui/material/TextField";
+import Button from "@mui/material/Button";
+import Typography from "@mui/material/Typography";
+import Checkbox from "@mui/material/Checkbox";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import Link from "@mui/material/Link";
+import IconButton from "@mui/material/IconButton";
+import InputAdornment from "@mui/material/InputAdornment";
+import Alert from "@mui/material/Alert";
+import Container from "@mui/material/Container";
+import Visibility from "@mui/icons-material/Visibility";
+import VisibilityOff from "@mui/icons-material/VisibilityOff";
+
+const strengthLevels = {
+  0: {
+    message: "Password must have at least 8 characters",
+    className: "strength-neutral",
+  },
+  1: {
+    message: "Weak",
+    className: "strength-weak",
+  },
+  2: {
+    message: "Fair",
+    className: "strength-fair",
+  },
+  3: {
+    message: "Good",
+    className: "strength-good",
+  },
+  4: {
+    message: "Strong",
+    className: "strength-strong",
+  },
+  5: {
+    message: "Very strong",
+    className: "strength-very-strong",
+  },
+};
+
+export function SignupForm({ onSubmit }) {
+  const [showPassword, setShowPassword] = useState(false);
+  const [submitStatus, setSubmitStatus] = useState(null);
+
+  const {
+    control,
+    handleSubmit,
+    formState: { errors, isValid, isSubmitting },
+  } = useForm({
+    mode: "onChange",
+    defaultValues: {
+      email: "",
+      fullName: "",
+      password: "",
+    },
+  });
+
+  function calculatePasswordStrength(password) {
+    if (!password || password.length < 8) {
+      return {
+        strength: 0,
+        message: strengthLevels[0].message,
+        className: strengthLevels[0].className,
+        neutral: true,
+      };
+    }
+
+    const length = password.length;
+    const hasLowercase = /[a-z]/.test(password);
+    const hasUppercase = /[A-Z]/.test(password);
+    const hasDigit = /[0-9]/.test(password);
+    const hasSpecialChar = /[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]/.test(password);
+
+    let score = 0;
+    let criteriaCount = 0;
+
+    if (hasLowercase) criteriaCount++;
+    if (hasUppercase) criteriaCount++;
+    if (hasDigit) criteriaCount++;
+    if (hasSpecialChar) criteriaCount++;
+
+    if (length >= 8 && length < 10) {
+      score = criteriaCount < 2 ? 1 : 2;
+    } else if (length >= 10 && length < 12) {
+      score = criteriaCount < 3 ? 2 : 3;
+    } else if (length >= 12 && length < 16) {
+      score = criteriaCount < 3 ? 3 : 4;
+    } else if (length >= 16) {
+      score = criteriaCount === 4 ? 5 : 4;
+    }
+
+    const mappedScore = Math.max(0, Math.min(score, 5));
+    return {
+      strength: mappedScore,
+      message: strengthLevels[mappedScore].message,
+      className: strengthLevels[mappedScore].className,
+      neutral: mappedScore === 0,
+    };
+  }
+
+  const watchedPassword = useWatch({ control, name: "password" });
+  const passwordStrength = calculatePasswordStrength(watchedPassword || "");
+
+  const handleFormSubmit = async data => {
+    try {
+      await onSubmit(data);
+    } catch (error) {
+      setSubmitStatus({
+        type: "error",
+        message:
+          error.message || "An unexpected error occurred. Please try again.",
+      });
+    }
+  };
+
+  return (
+    <Box className="signup-container">
+      <Container className="signup-wrapper" maxWidth={false}>
+        <Box className="signup-card">
+          <Box className="signup-header">
+            <Typography className="signup-title" component="h1">
+              Sign up for your account
+            </Typography>
+          </Box>
+
+          {submitStatus && (
+            <Alert
+              severity={submitStatus.type}
+              onClose={() => setSubmitStatus(null)}
+              sx={{ mb: 2 }}
+            >
+              {submitStatus.message}
+            </Alert>
+          )}
+
+          <Box
+            component="form"
+            onSubmit={handleSubmit(handleFormSubmit)}
+            noValidate
+          >
+            <Box className="signup-form-field">
+              <Typography className="signup-form-label" component="label">
+                Email address
+              </Typography>
+              <Controller
+                name="email"
+                control={control}
+                rules={{
+                  required: "Email is required",
+                  pattern: {
+                    value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
+                    message: "Invalid email address",
+                  },
+                }}
+                render={({ field }) => (
+                  <TextField
+                    {...field}
+                    placeholder="Enter email address"
+                    fullWidth
+                    variant="outlined"
+                    className="signup-text-field"
+                    error={!!errors.email}
+                    helperText={errors.email?.message}
+                  />
+                )}
+              />
+            </Box>
+
+            <Box className="signup-form-field">
+              <Typography className="signup-form-label" component="label">
+                Full name
+              </Typography>
+              <Controller
+                name="fullName"
+                control={control}
+                rules={{
+                  required: "Full name is required",
+                  minLength: {
+                    value: 2,
+                    message: "Name must be at least 2 characters",
+                  },
+                }}
+                render={({ field }) => (
+                  <TextField
+                    {...field}
+                    placeholder="Enter full name"
+                    fullWidth
+                    variant="outlined"
+                    className="signup-text-field"
+                    error={!!errors.fullName}
+                    helperText={errors.fullName?.message}
+                  />
+                )}
+              />
+            </Box>
+
+            <Box className="signup-form-field">
+              <Typography className="signup-form-label" component="label">
+                Password
+              </Typography>
+              <Controller
+                name="password"
+                control={control}
+                rules={{
+                  required: "Password must have at least 8 characters",
+                  minLength: {
+                    value: 8,
+                    message: "Password must have at least 8 characters",
+                  },
+                }}
+                render={({ field }) => (
+                  <TextField
+                    {...field}
+                    type={showPassword ? "text" : "password"}
+                    placeholder="Create password"
+                    fullWidth
+                    variant="outlined"
+                    className="signup-text-field"
+                    error={!!errors.password}
+                    slotProps={{
+                      input: {
+                        endAdornment: (
+                          <InputAdornment position="end">
+                            <IconButton
+                              onClick={() => setShowPassword(!showPassword)}
+                              className="signup-password-toggle"
+                              edge="end"
+                            >
+                              {showPassword ? (
+                                <VisibilityOff />
+                              ) : (
+                                <Visibility />
+                              )}
+                            </IconButton>
+                          </InputAdornment>
+                        ),
+                      },
+                    }}
+                  />
+                )}
+              />
+
+              <Box className="signup-password-strength">
+                <div className="strength-bars">
+                  {[1, 2, 3, 4, 5].map(barIndex => (
+                    <div
+                      key={barIndex}
+                      className={`strength-bar ${
+                        watchedPassword &&
+                        !passwordStrength.neutral &&
+                        barIndex <= passwordStrength.strength
+                          ? strengthLevels[passwordStrength.strength].className
+                          : strengthLevels[0].className
+                      }`}
+                      data-bar={barIndex}
+                    />
+                  ))}
+                </div>
+                <div className="strength-text strength-text-gray strength-text-center">
+                  {errors.password
+                    ? errors.password.message
+                    : passwordStrength.message}
+                </div>
+              </Box>
+            </Box>
+
+            <Box className="signup-form-field">
+              <FormControlLabel
+                className="signup-checkbox"
+                control={<Checkbox />}
+                label="Yes! Send me news and offers about products, events, and more."
+              />
+            </Box>
+
+            <Typography className="signup-legal-text">
+              By signing up, I accept the{" "}
+              <Link href="/terms" target="_blank">
+                Terms of Service
+              </Link>{" "}
+              and acknowledge the{" "}
+              <Link href="/privacy" target="_blank">
+                Privacy Policy
+              </Link>
+              .
+            </Typography>
+
+            <Button
+              type="submit"
+              fullWidth
+              className="signup-continue-button"
+              disabled={!isValid || isSubmitting}
+            >
+              {isSubmitting ? "Please wait..." : "Continue"}
+            </Button>
+          </Box>
+
+          <Box className="signup-footer">
+            <Typography className="signup-login-link">
+              Already have an account?{" "}
+              <RouterLink to="/login">Log in</RouterLink>
+            </Typography>
+          </Box>
+        </Box>
+      </Container>
+    </Box>
+  );
+}

--- a/src/pages/SignupPage.jsx
+++ b/src/pages/SignupPage.jsx
@@ -1,9 +1,19 @@
+import { useNavigate } from "react-router";
+
 import { SignupForm } from "../components/SignupForm";
+import { signup } from "../store/actions/auth-actions";
 
 export function SignupPage() {
-  const handleSignup = async formData => {
-    console.log("Signup data:", formData);
-  };
+  const navigate = useNavigate();
+
+  async function handleSignup(userData) {
+    try {
+      await signup(userData);
+      navigate("/");
+    } catch (error) {
+      console.error("Signup failed:", error);
+    }
+  }
 
   return <SignupForm onSubmit={handleSignup} />;
 }

--- a/src/pages/SignupPage.jsx
+++ b/src/pages/SignupPage.jsx
@@ -1,0 +1,9 @@
+import { SignupForm } from "../components/SignupForm";
+
+export function SignupPage() {
+  const handleSignup = async formData => {
+    console.log("Signup data:", formData);
+  };
+
+  return <SignupForm onSubmit={handleSignup} />;
+}

--- a/src/services/auth/auth-service-local.js
+++ b/src/services/auth/auth-service-local.js
@@ -1,0 +1,1 @@
+export const authService = {};

--- a/src/services/auth/auth-service-local.js
+++ b/src/services/auth/auth-service-local.js
@@ -11,9 +11,12 @@ const CURRENT_USER_SESSION_KEY = "currentUser";
 
 export async function signup(userData) {
   try {
-    const user = await storageService.post(USERS_STORAGE_KEY, userData);
-    setCurrentUserInSession(user);
-    return user;
+    const { password: _, ...userWithoutPassword } = await storageService.post(
+      USERS_STORAGE_KEY,
+      userData
+    );
+    setCurrentUserInSession(userWithoutPassword);
+    return userWithoutPassword;
   } catch (error) {
     console.error("Error during signup:", error);
     throw error;

--- a/src/services/auth/auth-service-local.js
+++ b/src/services/auth/auth-service-local.js
@@ -1,1 +1,29 @@
-export const authService = {};
+import { storageService } from "../async-storage-service";
+
+export const authService = {
+  signup,
+  setCurrentUserInSession,
+  getCurrentUserFromSession,
+};
+
+const USERS_STORAGE_KEY = "userDB";
+const CURRENT_USER_SESSION_KEY = "currentUser";
+
+export async function signup(userData) {
+  try {
+    const user = await storageService.post(USERS_STORAGE_KEY, userData);
+    setCurrentUserInSession(user);
+    return user;
+  } catch (error) {
+    console.error("Error during signup:", error);
+    throw error;
+  }
+}
+
+export function setCurrentUserInSession(user) {
+  sessionStorage.setItem(CURRENT_USER_SESSION_KEY, JSON.stringify(user));
+}
+export function getCurrentUserFromSession() {
+  const user = sessionStorage.getItem(CURRENT_USER_SESSION_KEY);
+  return user ? JSON.parse(user) : null;
+}

--- a/src/services/auth/auth-service-remote.js
+++ b/src/services/auth/auth-service-remote.js
@@ -1,0 +1,1 @@
+export const authService = {};

--- a/src/services/auth/auth-service-remote.js
+++ b/src/services/auth/auth-service-remote.js
@@ -1,1 +1,11 @@
-export const authService = {};
+export const authService = {
+  signup,
+  setCurrentUserInSession,
+  getCurrentUserFromSession,
+};
+
+export async function signup(userData) {}
+
+export function setCurrentUserInSession(user) {}
+
+export function getCurrentUserFromSession() {}

--- a/src/services/auth/index.js
+++ b/src/services/auth/index.js
@@ -1,0 +1,13 @@
+const { DEV, VITE_LOCAL } = import.meta.env;
+
+import { authService as local } from "./auth-service-local";
+import { authService as remote } from "./auth-service-remote";
+
+const service = VITE_LOCAL === "true" ? local : remote;
+export const authService = {
+  ...service,
+};
+
+if (DEV) {
+  window.authService = authService;
+}

--- a/src/store/actions/auth-actions.js
+++ b/src/store/actions/auth-actions.js
@@ -1,0 +1,20 @@
+import { SIGNUP } from "../reducers/auth-reducer";
+import { authService } from "../../services/auth";
+
+import { store } from "../store";
+
+export async function signup(userData) {
+  try {
+    store.dispatch({ type: SIGNUP.REQUEST, key: SIGNUP.KEY });
+    const user = await authService.signup(userData);
+    store.dispatch({ type: SIGNUP.SUCCESS, payload: user });
+    return user;
+  } catch (error) {
+    store.dispatch({
+      type: SIGNUP.FAILURE,
+      payload: error.message,
+      key: SIGNUP.KEY,
+    });
+    throw error;
+  }
+}

--- a/src/store/reducers/auth-reducer.js
+++ b/src/store/reducers/auth-reducer.js
@@ -1,0 +1,14 @@
+import { createAsyncActionTypes, createAsyncHandlers } from "../utils";
+
+const initialState = {
+  currentUser: null,
+  loading: {},
+  errors: {},
+};
+
+const handlers = {};
+
+export function authReducer(state = initialState, action) {
+  const handler = handlers[action.type];
+  return handler ? handler(state, action) : state;
+}

--- a/src/store/reducers/auth-reducer.js
+++ b/src/store/reducers/auth-reducer.js
@@ -1,12 +1,21 @@
 import { createAsyncActionTypes, createAsyncHandlers } from "../utils";
 
+export const SIGNUP = createAsyncActionTypes("SIGNUP");
+
 const initialState = {
   currentUser: null,
   loading: {},
   errors: {},
 };
 
-const handlers = {};
+const handlers = {
+  ...createAsyncHandlers(SIGNUP, SIGNUP.KEY),
+  [SIGNUP.SUCCESS]: (state, action) => ({
+    ...state,
+    loading: { ...state.loading, [SIGNUP.KEY]: false },
+    currentUser: action.payload,
+  }),
+};
 
 export function authReducer(state = initialState, action) {
   const handler = handlers[action.type];

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -2,10 +2,12 @@ import { legacy_createStore as createStore, combineReducers } from "redux";
 import { boardReducer } from "./reducers/board-reducer";
 import { userReducer } from "./reducers/user-reducer";
 import { uiReducer } from "./reducers/ui-reducer";
+import { authReducer } from "./reducers/auth-reducer";
 
 const rootReducer = combineReducers({
   boards: boardReducer,
   users: userReducer,
+  auth: authReducer,
   ui: uiReducer,
 });
 


### PR DESCRIPTION
## 🎯 Description
This feature intends to add functionality that enables users to sign up to the app.

## 🔧 Changes
- Add a local and remote `auth` services to separate authentication logic from users related logic.
- Add an `auth` reducer an action for managing `currentUser` and other authentication related state.
- Add Signup page with a form based on Trellos' design.

## 📝 Notes
### Design
Trello's original signup workflow has multiple steps and some additional components that not necessarily should be implemented in the same way in our app so I made some modifications.
<details>
  <summary>Click to expand</summary>

  <p align="center">
    <h3>Trello's signup flow</h3>
<img width="477" height="817" alt="Screenshot from 2025-11-08 19-59-14" src="https://github.com/user-attachments/assets/1cf5c8f0-52f3-4472-a934-4347d2e2d6c6" />
<img width="474" height="618" alt="2025-11-09_16-49" src="https://github.com/user-attachments/assets/631f188f-dd76-4013-8b7c-59d72ba964e8" />
<img width="451" height="732" alt="2025-11-09_16-49_1" src="https://github.com/user-attachments/assets/d551dae4-b179-4e19-8a7d-18cb33912612" />

 <h3>Our signup flow</h3>
<img width="473" height="735" alt="2025-11-10_19-33" src="https://github.com/user-attachments/assets/d6c477af-75c5-4514-ace4-62199080395e" />

  </p>

</details>


#### Modifications
- Avoid doing email verification.
- Use a single form for all the relevant data.
- Remove the signup using external services (Google, Slack, etc..).
- Remove some company related texts.
- Keep the marketing checkbox and legal section without company specific details for future implementation.

#### Technical notes
- The user is automatically logged in after signing up to avoid friction.
- The user is saved in session storage to mimic some sort of server authentication memory (without the password for obvious reasons).
- Avoid nesting `signup/login` routes under `auth` because it's not needed in our implementation.
- I grouped the variables I added in this feature under the components file instead the `vars.css` because we haven't yet figured out a design system that uses those variables in a consistent manner. so I've put them in this separate file not to pollute the global variables and for easier future refactoring.

## 🖥️ Demo

<details>
  <summary>Watch Demo Video</summary>

  <p align="center">

https://github.com/user-attachments/assets/dfa3e951-93c4-4e48-88f8-465d0e52729c


  </p>

</details>

