### PR TITLE
fix: Remove deleted labels from all cards in board

### DIFF
--- a/src/components/LabelMenu.jsx
+++ b/src/components/LabelMenu.jsx
@@ -58,11 +58,6 @@ export function LabelMenu({
 
   async function handleDeleteLabel(labelId) {
     await deleteLabel(boardId, labelId);
-
-    if (card.labels.includes(labelId)) {
-      handleToggleLabel(labelId);
-    }
-
     handleBack();
   }
 

--- a/src/services/board/board-service-local.js
+++ b/src/services/board/board-service-local.js
@@ -448,7 +448,18 @@ async function deleteLabel(boardId, labelId) {
 
     const updatedLabels = board.labels.filter(l => l.id !== labelId);
 
-    await updateBoard(boardId, { labels: updatedLabels });
+    const updatedLists = board.lists.map(list => ({
+      ...list,
+      cards: list.cards.map(card => ({
+        ...card,
+        labels: card.labels.filter(id => id !== labelId),
+      })),
+    }));
+
+    await updateBoard(boardId, {
+      labels: updatedLabels,
+      lists: updatedLists,
+    });
   } catch (error) {
     console.error("Cannot delete label:", error);
     throw error;

--- a/src/store/reducers/board-reducer.js
+++ b/src/store/reducers/board-reducer.js
@@ -180,6 +180,13 @@ const handlers = {
     board: {
       ...state.board,
       labels: state.board.labels.filter(l => l.id !== action.payload),
+      lists: state.board.lists.map(list => ({
+        ...list,
+        cards: list.cards.map(card => ({
+          ...card,
+          labels: card.labels.filter(id => id !== action.payload),
+        })),
+      })),
     },
   }),
   ...createAsyncHandlers(UPDATE_CARD_LABELS, UPDATE_CARD_LABELS.KEY),


### PR DESCRIPTION
## 🎯 Description

<!-- Briefly describe what this PR does -->

Fixed issue where deleted labels remained as IDs in cards across the board.
Now, deleted labels are completely removed from all cards - both visually and from their data.

## 🔧 Changes

- Update `deleteLabel` in `boardService` to remove `labelId` from all cards
- Update `DELETE_LABEL.SUCCESS` reducer to clean cards' `labels` array
- Simplify `LabelMenu.handleDeleteLabel` (no manual toggle needed)
- Ensures deleted labels are removed from the entire board, not just from the opened card