### PR TITLE
feature/CATC_89-incorporate-atlassian-design-system-into-a-mui-theme

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ca-trello-clone",
       "version": "0.0.1",
       "dependencies": {
+        "@atlaskit/tokens": "^8.0.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@hookform/resolvers": "^5.2.2",
@@ -36,6 +37,74 @@
         "eslint-plugin-react-refresh": "^0.4.23",
         "globals": "^16.4.0",
         "vite": "^7.1.9"
+      }
+    },
+    "node_modules/@atlaskit/atlassian-context": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/atlassian-context/-/atlassian-context-0.6.0.tgz",
+      "integrity": "sha512-TjaV1OIjP8DaOyaqzPI5OkYvVckn3hYwE92v8RcdnpOiMKI0taedg1sLXD7x0nPx5MtXPmCJNNVJJprDN7pmxQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/@atlaskit/ds-lib": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/ds-lib/-/ds-lib-5.2.0.tgz",
+      "integrity": "sha512-ud0Vn/JHyZeHsdWGXue1XPTYSR/Br7VZEJkhisWMtRqLe0VRbUlRMH20fjC/24vlSBqjcUBK2L8gWd3SywU49A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@atlaskit/platform-feature-flags": "^1.1.0",
+        "@babel/runtime": "^7.0.0",
+        "bind-event-listener": "^3.0.0",
+        "react-uid": "^2.2.0",
+        "tiny-invariant": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/@atlaskit/feature-gate-js-client": {
+      "version": "5.5.7",
+      "resolved": "https://registry.npmjs.org/@atlaskit/feature-gate-js-client/-/feature-gate-js-client-5.5.7.tgz",
+      "integrity": "sha512-m2ATuJChdHLJdFxpfm5HPnBzjtg8yJFLdZmZguP24oFJI1562y7JbOSEmrRtbzyOIuuqjSUrcNA/el3+srkjrw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@atlaskit/atlassian-context": "^0.6.0",
+        "@babel/runtime": "^7.0.0",
+        "@statsig/client-core": "^3.21.1",
+        "@statsig/js-client": "^3.21.1",
+        "eventemitter3": "^4.0.0"
+      }
+    },
+    "node_modules/@atlaskit/platform-feature-flags": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@atlaskit/platform-feature-flags/-/platform-feature-flags-1.1.2.tgz",
+      "integrity": "sha512-PM+fVkV4Yn4/0keiN6ioAap2Y+odTyw1Z4uf+TA0zMmg3/lp/rVNJEc4a24dvd8DfVs5m9bxa/hbO1qJarhCBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@atlaskit/feature-gate-js-client": "^5.5.0",
+        "@babel/runtime": "^7.0.0"
+      }
+    },
+    "node_modules/@atlaskit/tokens": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-8.0.0.tgz",
+      "integrity": "sha512-Y8bOPN+ByEJ7Nd3XoWLEkY4bdD3Za29I3l9rVKsEK2IbMXPl6n62zWSZh2Nt4j4N58wKKuOk1X3zO5ib+HWfrQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@atlaskit/ds-lib": "^5.2.0",
+        "@atlaskit/platform-feature-flags": "^1.1.0",
+        "@babel/runtime": "^7.0.0",
+        "@babel/traverse": "^7.23.2",
+        "@babel/types": "^7.20.0",
+        "bind-event-listener": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1767,6 +1836,21 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
+    "node_modules/@statsig/client-core": {
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@statsig/client-core/-/client-core-3.30.0.tgz",
+      "integrity": "sha512-Cahu+goQ/KSjMxwsq22v84I6Fbx9msAval9uh4f+rf2n1/11FEZx7oP8/lqefa/XMOyQAJfgIlKZLH15EPRS+Q==",
+      "license": "ISC"
+    },
+    "node_modules/@statsig/js-client": {
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@statsig/js-client/-/js-client-3.30.0.tgz",
+      "integrity": "sha512-qD0nWQ6ZqhZxPYwofntkiU5onpiS0Iqc0FZSTdqoCzX2tCyorNieJMIWu8R+40qD/1xSQPpmIWxBN4aa42TbSg==",
+      "license": "ISC",
+      "dependencies": {
+        "@statsig/client-core": "3.30.0"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1842,6 +1926,7 @@
       "version": "19.2.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2168,6 +2253,12 @@
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
       }
+    },
+    "node_modules/bind-event-listener": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bind-event-listener/-/bind-event-listener-3.0.0.tgz",
+      "integrity": "sha512-PJvH288AWQhKs2v9zyfYdPzlPqf5bXbGMmhmUIY9x4dAUGIWgomO771oBQNwJnMQSnUIXhKu6sgzpBRXTlvb8Q==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -3107,6 +3198,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4755,6 +4852,27 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/react-uid": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/react-uid/-/react-uid-2.4.0.tgz",
+      "integrity": "sha512-+MVs/25NrcZuGrmlVRWPOSsbS8y72GJOBsR7d68j3/wqOrRBF52U29XAw4+XSelw0Vm6s5VmGH5mCbTCPGVCVg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -5344,6 +5462,12 @@
       "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
       "license": "MIT"
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -5366,6 +5490,12 @@
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
       "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
       "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -5764,21 +5894,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@atlaskit/tokens": "^8.0.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@hookform/resolvers": "^5.2.2",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,6 +12,7 @@ import { AdminIndex } from "./pages/AdminIndex";
 // import { Login } from "./pages/LoginSignup";
 import { SignupPage } from "./pages/SignupPage";
 import { LoginPage } from "./pages/LoginPage";
+import ThemeComparison from "./pages/ThemeComparison";
 
 export function App() {
   const location = useLocation();
@@ -36,6 +37,7 @@ export function App() {
           <Route path="admin" element={<AdminIndex />} />
           <Route path="signup" element={<SignupPage />} />
           <Route path="login" element={<LoginPage />} />
+          <Route path="theme-comparison" element={<ThemeComparison />} />
         </Routes>
         {backgroundLocation && (
           <Routes>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,22 +1,26 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-
 import { BrowserRouter as Router } from "react-router-dom";
 import { Provider } from "react-redux";
+import { ThemeProvider } from "@mui/material/styles";
+import CssBaseline from "@mui/material/CssBaseline";
 
 import * as serviceWorkerRegistration from "./serviceWorkerRegistration";
-
 import { store } from "./store/store";
 import { App } from "./App";
+import muiTheme from "./theme/muiTheme";
 
 import "./assets/styles/main.css";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <Provider store={store}>
-    <Router>
-      <App />
-    </Router>
+    <ThemeProvider theme={muiTheme}>
+      <CssBaseline />
+      <Router>
+        <App />
+      </Router>
+    </ThemeProvider>
   </Provider>
 );
 

--- a/frontend/src/pages/ThemeComparison.jsx
+++ b/frontend/src/pages/ThemeComparison.jsx
@@ -1,0 +1,413 @@
+import { useState } from "react";
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CardActions,
+  Chip,
+  Container,
+  Paper,
+  TextField,
+  Typography,
+  Tooltip,
+  Badge,
+  Stack,
+  Grid,
+  ThemeProvider,
+  createTheme,
+} from "@mui/material";
+import muiTheme from "../theme/muiTheme";
+
+// Default MUI theme for comparison
+const defaultTheme = createTheme();
+
+// Shared component section that's rendered identically on both sides
+const ComponentShowcase = () => (
+  <>
+    {/* Typography Section */}
+    <Box sx={{ mb: 4 }}>
+      <Typography variant="h4" gutterBottom>
+        Typography
+      </Typography>
+      <Stack spacing={2}>
+        <Typography variant="h1">Heading 1</Typography>
+        <Typography variant="h2">Heading 2</Typography>
+        <Typography variant="h3">Heading 3</Typography>
+        <Typography variant="h4">Heading 4</Typography>
+        <Typography variant="h5">Heading 5</Typography>
+        <Typography variant="h6">Heading 6</Typography>
+        <Typography variant="body1">
+          Body 1: The quick brown fox jumps over the lazy dog
+        </Typography>
+        <Typography variant="body2">
+          Body 2: The quick brown fox jumps over the lazy dog
+        </Typography>
+        <Typography variant="button">Button Text</Typography>
+        <Typography variant="caption">Caption text</Typography>
+        <Typography variant="overline">Overline text</Typography>
+      </Stack>
+    </Box>
+
+    {/* Spacing Section */}
+    <Box sx={{ mb: 4 }}>
+      <Typography variant="h4" gutterBottom>
+        Spacing
+      </Typography>
+      <Stack spacing={2}>
+        {[0, 1, 2, 3, 4, 5, 6, 8].map(factor => (
+          <Box
+            key={factor}
+            sx={{
+              p: factor,
+              bgcolor: "primary.main",
+              color: "primary.contrastText",
+              display: "inline-block",
+            }}
+          >
+            spacing({factor})
+          </Box>
+        ))}
+      </Stack>
+    </Box>
+
+    {/* Elevation Section */}
+    <Box sx={{ mb: 4 }}>
+      <Typography variant="h4" gutterBottom>
+        Elevation / Shadows
+      </Typography>
+      <Grid container spacing={2}>
+        {[0, 1, 2, 3, 8, 24].map(elevation => (
+          <Grid item xs={6} sm={4} key={elevation}>
+            <Paper
+              elevation={elevation}
+              sx={{
+                p: 2,
+                textAlign: "center",
+                height: 100,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              <Typography variant="body2">Elevation {elevation}</Typography>
+            </Paper>
+          </Grid>
+        ))}
+      </Grid>
+    </Box>
+
+    {/* Components Section */}
+    <Box sx={{ mb: 4 }}>
+      <Typography variant="h4" gutterBottom>
+        Components
+      </Typography>
+
+      <Stack spacing={3}>
+        {/* Buttons */}
+        <Box>
+          <Typography variant="h6" gutterBottom>
+            Buttons
+          </Typography>
+          <Stack direction="row" spacing={2} flexWrap="wrap" useFlexGap>
+            <Button variant="contained">Contained</Button>
+            <Button variant="outlined">Outlined</Button>
+            <Button variant="text">Text</Button>
+            <Button variant="contained" color="secondary">
+              Secondary
+            </Button>
+            <Button variant="contained" disabled>
+              Disabled
+            </Button>
+          </Stack>
+        </Box>
+
+        {/* Text Fields */}
+        <Box>
+          <Typography variant="h6" gutterBottom>
+            Text Fields
+          </Typography>
+          <Stack direction="row" spacing={2} flexWrap="wrap" useFlexGap>
+            <TextField label="Outlined" variant="outlined" />
+            <TextField label="Filled" variant="filled" />
+            <TextField label="Standard" variant="standard" />
+          </Stack>
+        </Box>
+
+        {/* Cards */}
+        <Box>
+          <Typography variant="h6" gutterBottom>
+            Cards
+          </Typography>
+          <Grid container spacing={2}>
+            {[1, 2, 3].map(i => (
+              <Grid item xs={12} sm={4} key={i}>
+                <Card>
+                  <CardContent>
+                    <Typography variant="h5" component="div">
+                      Card {i}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      This is a sample card with content to demonstrate styling.
+                    </Typography>
+                  </CardContent>
+                  <CardActions>
+                    <Button size="small">Learn More</Button>
+                  </CardActions>
+                </Card>
+              </Grid>
+            ))}
+          </Grid>
+        </Box>
+
+        {/* Chips */}
+        <Box>
+          <Typography variant="h6" gutterBottom>
+            Chips
+          </Typography>
+          <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+            <Chip label="Default" />
+            <Chip label="Primary" color="primary" />
+            <Chip label="Secondary" color="secondary" />
+            <Chip label="Success" color="success" />
+            <Chip label="Error" color="error" />
+            <Chip label="Deletable" onDelete={() => {}} />
+          </Stack>
+        </Box>
+
+        {/* Badges & Tooltips */}
+        <Box>
+          <Typography variant="h6" gutterBottom>
+            Badges & Tooltips
+          </Typography>
+          <Stack direction="row" spacing={2} flexWrap="wrap" useFlexGap>
+            <Badge badgeContent={4} color="primary">
+              <Button variant="outlined">Messages</Button>
+            </Badge>
+            <Badge badgeContent={100} color="secondary">
+              <Button variant="outlined">Notifications</Button>
+            </Badge>
+            <Tooltip title="This is a tooltip">
+              <Button variant="outlined">Hover me</Button>
+            </Tooltip>
+          </Stack>
+        </Box>
+      </Stack>
+    </Box>
+  </>
+);
+
+const ThemeComparison = () => {
+  const [activeTheme, setActiveTheme] = useState("split");
+
+  // Single theme view
+  if (activeTheme !== "split") {
+    const theme = activeTheme === "default" ? defaultTheme : muiTheme;
+    const themeName = activeTheme === "default" ? "Default MUI" : "ADS";
+
+    return (
+      <ThemeProvider theme={theme}>
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            height: "100vh",
+            overflow: "hidden",
+          }}
+        >
+          {/* Header */}
+          <Box
+            sx={{
+              p: 3,
+              bgcolor: "background.paper",
+              borderBottom: 1,
+              borderColor: "divider",
+            }}
+          >
+            <Typography variant="h4" align="center" gutterBottom>
+              Theme Comparison Demo
+            </Typography>
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              align="center"
+              gutterBottom
+            >
+              Viewing: {themeName} Theme
+            </Typography>
+            <Stack
+              direction="row"
+              spacing={2}
+              justifyContent="center"
+              flexWrap="wrap"
+              useFlexGap
+              sx={{ mt: 2 }}
+            >
+              <Button
+                variant={activeTheme === "default" ? "contained" : "outlined"}
+                onClick={() => setActiveTheme("default")}
+              >
+                Default MUI
+              </Button>
+              <Button
+                variant={activeTheme === "ads" ? "contained" : "outlined"}
+                onClick={() => setActiveTheme("ads")}
+              >
+                ADS Theme
+              </Button>
+              <Button
+                variant={activeTheme === "split" ? "contained" : "outlined"}
+                onClick={() => setActiveTheme("split")}
+              >
+                Split View
+              </Button>
+            </Stack>
+          </Box>
+
+          {/* Scrollable Content */}
+          <Box
+            sx={{ flex: 1, overflow: "auto", bgcolor: "background.default" }}
+          >
+            <Container maxWidth="lg" sx={{ py: 4 }}>
+              <ComponentShowcase />
+            </Container>
+          </Box>
+        </Box>
+      </ThemeProvider>
+    );
+  }
+
+  // Split view
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        height: "100vh",
+        overflow: "hidden",
+      }}
+    >
+      {/* Fixed Header */}
+      <Box
+        sx={{
+          bgcolor: "white",
+          borderBottom: 1,
+          borderColor: "divider",
+          py: 2,
+          px: 2,
+          flexShrink: 0,
+        }}
+      >
+        <Container maxWidth="xl">
+          <Typography variant="h5" align="center" gutterBottom>
+            Theme Comparison Demo
+          </Typography>
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            align="center"
+            gutterBottom
+          >
+            Compare Default MUI Theme vs Custom ADS-Integrated Theme
+          </Typography>
+          <Stack
+            direction="row"
+            spacing={2}
+            justifyContent="center"
+            flexWrap="wrap"
+            useFlexGap
+            sx={{ mt: 1 }}
+          >
+            <Button
+              size="small"
+              variant={activeTheme === "default" ? "contained" : "outlined"}
+              onClick={() => setActiveTheme("default")}
+            >
+              Default MUI Only
+            </Button>
+            <Button
+              size="small"
+              variant={activeTheme === "ads" ? "contained" : "outlined"}
+              onClick={() => setActiveTheme("ads")}
+            >
+              ADS Theme Only
+            </Button>
+            <Button
+              size="small"
+              variant={activeTheme === "split" ? "contained" : "outlined"}
+              onClick={() => setActiveTheme("split")}
+            >
+              Split View
+            </Button>
+          </Stack>
+        </Container>
+      </Box>
+
+      {/* Scrollable Content Area with Split View */}
+      <Box sx={{ flex: 1, overflow: "auto", bgcolor: "#f5f5f5", p: 2 }}>
+        <Box sx={{ display: "flex", gap: 2, minHeight: "100%" }}>
+          {/* Default MUI Theme Column */}
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <Paper
+              sx={{
+                height: "100%",
+                display: "flex",
+                flexDirection: "column",
+              }}
+            >
+              <Box
+                sx={{
+                  p: 2,
+                  bgcolor: "primary.main",
+                  color: "primary.contrastText",
+                  flexShrink: 0,
+                }}
+              >
+                <Typography variant="h6" align="center">
+                  Default MUI Theme
+                </Typography>
+              </Box>
+              <Box sx={{ p: 3, overflow: "auto" }}>
+                <ThemeProvider theme={defaultTheme}>
+                  <ComponentShowcase />
+                </ThemeProvider>
+              </Box>
+            </Paper>
+          </Box>
+
+          {/* ADS Theme Column */}
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <Paper
+              sx={{
+                height: "100%",
+                display: "flex",
+                flexDirection: "column",
+                bgcolor: "#fafbfc",
+              }}
+            >
+              <Box
+                sx={{
+                  p: 2,
+                  bgcolor: "secondary.main",
+                  color: "secondary.contrastText",
+                  flexShrink: 0,
+                }}
+              >
+                <Typography variant="h6" align="center">
+                  ADS Theme
+                </Typography>
+              </Box>
+              <Box sx={{ p: 3, overflow: "auto" }}>
+                <ThemeProvider theme={muiTheme}>
+                  <ComponentShowcase />
+                </ThemeProvider>
+              </Box>
+            </Paper>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default ThemeComparison;

--- a/frontend/src/theme/muiTheme.js
+++ b/frontend/src/theme/muiTheme.js
@@ -5,6 +5,7 @@ setGlobalTheme({
   colorMode: "auto",
   shape: "shape",
   typography: "typography",
+  elevation: "elevation",
 });
 
 const FONT_FALLBACK =
@@ -140,6 +141,41 @@ const muiTheme = createTheme({
       textTransform: "uppercase",
     },
   },
+
+  /**
+   * Shadows Configuration (Elevation)
+   *
+   * Maps MUI shadow levels to ADS elevation tokens.
+   * MUI expects an array of 25 shadow values (0-24).
+   *
+   * ADS provides 3 shadow levels:
+   * - elevation.shadow.raised (subtle)
+   * - elevation.shadow.overflow (medium)
+   * - elevation.shadow.overlay (strong)
+   *
+   * Mapping:
+   * 0: none
+   * 1: raised
+   * 2: overflow
+   * 3-24: overlay (repeated for remaining indices)
+   */
+  shadows: [
+    "none",
+    token(
+      "elevation.shadow.raised",
+      "0px 1px 1px rgba(30, 31, 33, 0.25), 0px 0px 1px rgba(30, 31, 33, 0.31)"
+    ),
+    token(
+      "elevation.shadow.overflow",
+      "0px 0px 8px rgba(30, 31, 33, 0.16), 0px 0px 1px rgba(30, 31, 33, 0.12)"
+    ),
+    ...Array(22).fill(
+      token(
+        "elevation.shadow.overlay",
+        "0px 8px 12px rgba(30, 31, 33, 0.15), 0px 0px 1px rgba(30, 31, 33, 0.31)"
+      )
+    ), // Indices 3-24 (22 elements)
+  ],
 });
 
 export default muiTheme;

--- a/frontend/src/theme/muiTheme.js
+++ b/frontend/src/theme/muiTheme.js
@@ -1,0 +1,11 @@
+import { createTheme } from "@mui/material/styles";
+import { setGlobalTheme, token } from "@atlaskit/tokens";
+
+setGlobalTheme({
+  colorMode: "auto",
+  shape: "shape",
+});
+
+const muiTheme = createTheme({});
+
+export default muiTheme;

--- a/frontend/src/theme/muiTheme.js
+++ b/frontend/src/theme/muiTheme.js
@@ -2,7 +2,7 @@ import { createTheme } from "@mui/material/styles";
 import { setGlobalTheme, token } from "@atlaskit/tokens";
 
 setGlobalTheme({
-  colorMode: "auto",
+  colorMode: "light",
   shape: "shape",
   typography: "typography",
   elevation: "elevation",
@@ -140,6 +140,71 @@ const muiTheme = createTheme({
       fontWeight: token("font.weight.regular", "400"),
       textTransform: "uppercase",
     },
+  },
+
+  /**
+   * Palette Configuration
+   *
+   * Maps MUI color system to ADS color tokens using token() function.
+   * This provides dynamic theming capabilities but generates MUI warnings
+   * about color channels (which is expected and acceptable).
+   *
+   * Color Mapping:
+   * - primary → brand (blue)
+   * - secondary → neutral (gray)
+   * - error → danger (red)
+   * - warning → warning (orange/yellow)
+   * - info → information (blue)
+   * - success → success (green)
+   *
+   * Note: MUI will show warnings about palette.defaultChannel because
+   * CSS variables can't be parsed for channel generation. This is
+   * expected and doesn't affect functionality.
+   */
+  cssVariables: true,
+  palette: {
+    primary: {
+      main: token("color.background.brand.bold", "#1868DB"),
+      light: token("color.background.brand.subtlest", "#E9F2FE"),
+      dark: token("color.background.brand.boldest", "#123263"),
+      contrastText: token("color.text.inverse", "#FFFFFF"),
+    },
+    secondary: {
+      main: token("color.background.neutral.bold", "#505258"),
+      light: token("color.background.neutral", "#F7F8F9"),
+      dark: token("color.background.neutral.bold.pressed", "#3B3D42"),
+      contrastText: token("color.text.inverse", "#FFFFFF"),
+    },
+    error: {
+      main: token("color.background.danger.bold", "#C9372C"),
+      light: token("color.background.danger", "#FFECEB"),
+      dark: token("color.background.danger.bold.pressed", "#872821"),
+      contrastText: token("color.text.inverse", "#FFFFFF"),
+    },
+    warning: {
+      main: token("color.background.warning.bold", "#FCA700"),
+      light: token("color.background.warning", "#FFF5DB"),
+      dark: token("color.background.warning.bold.pressed", "#F68909"),
+      contrastText: token("color.text", "#292A2E"),
+    },
+    info: {
+      main: token("color.background.information.bold", "#1868DB"),
+      light: token("color.background.information", "#E9F2FE"),
+      dark: token("color.background.information.bold.pressed", "#144794"),
+      contrastText: token("color.text.inverse", "#FFFFFF"),
+    },
+    success: {
+      main: token("color.background.success.bold", "#6A9A23"),
+      light: token("color.background.success", "#EFFFD6"),
+      dark: token("color.background.success.bold.pressed", "#3F5224"),
+      contrastText: token("color.text.inverse", "#FFFFFF"),
+    },
+    text: {
+      primary: token("color.text", "#292A2E"),
+      secondary: token("color.text.subtle", "#626F86"),
+      disabled: token("color.text.disabled", "#7D818A"),
+    },
+    divider: token("color.border", "rgba(11, 18, 14, 0.14)"),
   },
 
   /**

--- a/frontend/src/theme/muiTheme.js
+++ b/frontend/src/theme/muiTheme.js
@@ -4,7 +4,11 @@ import { setGlobalTheme, token } from "@atlaskit/tokens";
 setGlobalTheme({
   colorMode: "auto",
   shape: "shape",
+  typography: "typography",
 });
+
+const FONT_FALLBACK =
+  'ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", Ubuntu, "Helvetica Neue", sans-serif';
 
 const muiTheme = createTheme({
   /**
@@ -46,6 +50,95 @@ const muiTheme = createTheme({
    */
   shape: {
     borderRadius: token("radius.small", "0.25rem"),
+  },
+
+  /**
+   * Typography Configuration
+   *
+   * Maps MUI typography variants to ADS font scales.
+   * - Uses token() for fontFamily and fontWeight (CSS variables)
+   * - fontSize and lineHeight are hardcoded rem values based on ADS scales
+   *   (ADS doesn't provide separate fontSize/lineHeight tokens)
+   *
+   * ADS Font Scale Mapping:
+   * h1 → font.heading.xxlarge (35px/500)
+   * h2 → font.heading.xlarge  (29px/600)
+   * h3 → font.heading.large   (24px/500)
+   * h4 → font.heading.medium  (20px/500)
+   * h5 → font.heading.small   (16px/600)
+   * h6 → font.heading.xsmall  (14px/600)
+   * body1 → font.body         (14px/400)
+   * body2 → font.body.small   (11px/400)
+   */
+  typography: {
+    fontFamily: token("font.family.body", FONT_FALLBACK),
+    fontWeightLight: 300,
+    fontWeightRegular: token("font.weight.regular", "400"),
+    fontWeightMedium: token("font.weight.medium", "500"),
+    fontWeightBold: token("font.weight.bold", "700"),
+
+    h1: {
+      fontFamily: token("font.family.heading", FONT_FALLBACK),
+      fontSize: "2.1875rem",
+      lineHeight: "2.5rem",
+      fontWeight: token("font.weight.medium", "500"),
+    },
+    h2: {
+      fontFamily: token("font.family.heading", FONT_FALLBACK),
+      fontSize: "1.8125rem",
+      lineHeight: "2rem",
+      fontWeight: token("font.weight.semibold", "600"),
+    },
+    h3: {
+      fontFamily: token("font.family.heading", FONT_FALLBACK),
+      fontSize: "1.5rem",
+      lineHeight: "1.75rem",
+      fontWeight: token("font.weight.medium", "500"),
+    },
+    h4: {
+      fontFamily: token("font.family.heading", FONT_FALLBACK),
+      fontSize: "1.25rem",
+      lineHeight: "1.5rem",
+      fontWeight: token("font.weight.medium", "500"),
+    },
+    h5: {
+      fontFamily: token("font.family.heading", FONT_FALLBACK),
+      fontSize: "1rem",
+      lineHeight: "1.25rem",
+      fontWeight: token("font.weight.semibold", "600"),
+    },
+    h6: {
+      fontFamily: token("font.family.heading", FONT_FALLBACK),
+      fontSize: "0.875rem",
+      lineHeight: "1rem",
+      fontWeight: token("font.weight.semibold", "600"),
+    },
+    body1: {
+      fontSize: "0.875rem",
+      lineHeight: "1.25rem",
+      fontWeight: token("font.weight.regular", "400"),
+    },
+    body2: {
+      fontSize: "0.6875rem",
+      lineHeight: "1rem",
+      fontWeight: token("font.weight.regular", "400"),
+    },
+    button: {
+      fontSize: "0.875rem",
+      fontWeight: token("font.weight.medium", "500"),
+      textTransform: "none",
+    },
+    caption: {
+      fontSize: "0.6875rem",
+      lineHeight: "1rem",
+      fontWeight: token("font.weight.regular", "400"),
+    },
+    overline: {
+      fontSize: "0.6875rem",
+      lineHeight: "1rem",
+      fontWeight: token("font.weight.regular", "400"),
+      textTransform: "uppercase",
+    },
   },
 });
 

--- a/frontend/src/theme/muiTheme.js
+++ b/frontend/src/theme/muiTheme.js
@@ -35,6 +35,18 @@ const muiTheme = createTheme({
 
     return spacingMap[factor] ?? `${factor * 0.5}rem`;
   },
+
+  /**
+   * Shape Configuration
+   *
+   * Uses ADS radius.small as the default border radius.
+   * This provides a consistent 4px (0.25rem) border radius across components.
+   *
+   * Larger components can override to radius.medium or radius.large in styleOverrides.
+   */
+  shape: {
+    borderRadius: token("radius.small", "0.25rem"),
+  },
 });
 
 export default muiTheme;

--- a/frontend/src/theme/muiTheme.js
+++ b/frontend/src/theme/muiTheme.js
@@ -6,6 +6,35 @@ setGlobalTheme({
   shape: "shape",
 });
 
-const muiTheme = createTheme({});
+const muiTheme = createTheme({
+  /**
+   * Spacing System - Complete ADS Token Mapping
+   *
+   * Maps MUI spacing factors to all available ADS space tokens.
+   * ADS provides tokens from space.0 (0rem) to space.1000 (5rem).
+   *
+   * Usage: spacing(2) → var(--ds-space-200, 1rem)
+   */
+  spacing: factor => {
+    const spacingMap = {
+      0: token("space.0", "0rem"), // 0px
+      0.25: token("space.025", "0.125rem"), // 2px
+      0.5: token("space.050", "0.25rem"), // 4px
+      0.75: token("space.075", "0.375rem"), // 6px
+      1: token("space.100", "0.5rem"), // 8px
+      1.5: token("space.150", "0.75rem"), // 12px
+      2: token("space.200", "1rem"), // 16px
+      2.5: token("space.250", "1.25rem"), // 20px
+      3: token("space.300", "1.5rem"), // 24px
+      4: token("space.400", "2rem"), // 32px
+      5: token("space.500", "2.5rem"), // 40px
+      6: token("space.600", "3rem"), // 48px
+      8: token("space.800", "4rem"), // 64px
+      10: token("space.1000", "5rem"), // 80px
+    };
+
+    return spacingMap[factor] ?? `${factor * 0.5}rem`;
+  },
+});
 
 export default muiTheme;


### PR DESCRIPTION
## 🎯 Description

Integrates Atlassian Design System (ADS) tokens into the Material UI theme for the Trello clone frontend. All theme values for colors, spacing, typography, and elevation now use ADS tokens for consistent design.

## 🔧 Changes
- 🎨 MUI palette colors mapped to ADS tokens (primary, secondary, error, warning, info, success, divider)
- 🟦 Spacing system uses ADS space tokens
- 🅰️ Typography uses ADS font tokens; fallback font string extracted to a constant for DRYness
- 🪟 ThemeComparison page added/updated to compare default MUI theme vs. ADS-powered theme
- 🕶️ Elevation/shadows mapped to ADS elevation tokens

## 📝 Notes
- MUI will show warnings about palette.defaultChannel due to CSS variable usage—this is expected and does not affect functionality
- All theme changes are isolated to `frontend/src/theme/muiTheme.js`
- No breaking changes for existing components; all MUI components now inherit ADS styling automatically.
- We don't have access to the proprietary Atlassian fonts, so we need to find similar free ones.

---

## 🖥️ Demo


<details>
  <summary>Watch Demo Video</summary>

  <p align="center">

https://github.com/user-attachments/assets/0a5d7287-0461-4d92-ad56-8608ce53a5cb


  </p>

</details>
