### PR TITLE
Added the copy link functionality in card menu #CATC-116

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -138,7 +138,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -454,7 +453,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -498,7 +496,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1311,7 +1308,6 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.4.tgz",
       "integrity": "sha512-gEQL9pbJZZHT7lYJBKQCS723v1MGys2IFc94COXbUIyCTWa+qC77a7hUax4Yjd5ggEm35dk4AyYABpKKWC4MLw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/core-downloads-tracker": "^7.3.4",
@@ -1933,7 +1929,6 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1990,7 +1985,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2298,7 +2292,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -2977,7 +2970,6 @@
       "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4645,7 +4637,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4746,7 +4737,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4756,7 +4746,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4769,7 +4758,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.64.0.tgz",
       "integrity": "sha512-fnN+vvTiMLnRqKNTVhDysdrUay0kUUAymQnFIznmgDvapjveUWOOPqMNzPg+A+0yf9DuE2h6xzBjN1s+Qx8wcg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -4899,8 +4887,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -5698,7 +5685,6 @@
       "integrity": "sha512-4nVGliEpxmhCL8DslSAUdxlB6+SMrhB0a1v5ijlh1xB1nEPuy1mxaHxysVucLHuWryAxLWg6a5ei+U4TLn/rFg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -5950,7 +5936,6 @@
       "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -37,6 +37,10 @@ export function App() {
           <Route path="admin" element={<AdminIndex />} />
           <Route path="signup" element={<SignupPage />} />
           <Route path="login" element={<LoginPage />} />
+          <Route
+            path="board/:boardId/:listId/:cardId"
+            element={<CardDetails />}
+          />
           <Route path="theme-comparison" element={<ThemeComparison />} />
         </Routes>
         {backgroundLocation && (

--- a/frontend/src/components/CardPopover.jsx
+++ b/frontend/src/components/CardPopover.jsx
@@ -8,6 +8,7 @@ import {
   LinkOutlined,
   ArchiveOutlined,
   OpenInNew,
+  Check,
 } from "@mui/icons-material";
 import { useState } from "react";
 import { PopoverMenuProvider } from "./card/PopoverMenuProvider";
@@ -27,6 +28,7 @@ export default function CardPopover({
 }) {
   const [popoverAnchorEl, setPopoverAnchorEl] = useState(null);
   const [activeMenuItem, setActiveMenuItem] = useState(null);
+  const [copiedLink, setCopiedLink] = useState(false);
   const { boardId } = useParams();
 
   function handleOpen() {
@@ -50,6 +52,15 @@ export default function CardPopover({
   function handleMoveCardClick(e) {
     setPopoverAnchorEl(e.currentTarget);
     setActiveMenuItem("moveCard");
+  }
+
+  function handleCopyLinkClick(e) {
+    e.stopPropagation();
+    navigator.clipboard.writeText(
+      `${window.location.origin}/board/${boardId}/${listId}/${card.id}`
+    );
+    setCopiedLink(true);
+    setTimeout(() => setCopiedLink(false), 2000);
   }
 
   function handleCopyCardSubmit(formData) {
@@ -104,6 +115,7 @@ export default function CardPopover({
       open: handleOpen,
       editLabels: handleEditLabels,
       copyCard: handleCopyCardClick,
+      copyLink: handleCopyLinkClick,
       moveCard: handleMoveCardClick,
       archive: handleArchive,
     };
@@ -165,7 +177,11 @@ export default function CardPopover({
                 activeMenuItem === key ? "is-active" : ""
               }`}
             >
-              {icon}
+              {key === "copyLink" && copiedLink ? (
+                <Check sx={{ color: "#22c55e" }} />
+              ) : (
+                icon
+              )}
               {label}
             </button>
           ))}

--- a/frontend/src/pages/BoardDetails.jsx
+++ b/frontend/src/pages/BoardDetails.jsx
@@ -113,7 +113,9 @@ export function BoardDetails() {
     // Add your custom logic for each menu item
   }
 
-  if (!board) return <div>Loading board...</div>;
+  if (!board) {
+    return <section className="board-container">Loading...</section>;
+  }
 
   return (
     <section className="board-container">

--- a/frontend/src/pages/CardDetails.jsx
+++ b/frontend/src/pages/CardDetails.jsx
@@ -2,11 +2,15 @@ import { useSelector } from "react-redux";
 import { useParams, useNavigate } from "react-router-dom";
 import { CardModal } from "../components/CardModal";
 import { useState, useEffect } from "react";
-import { deleteCard, editCard } from "../store/actions/board-actions";
+import {
+  deleteCard,
+  editCard,
+  loadBoard,
+} from "../store/actions/board-actions";
 
 export function CardDetails() {
   const { boardId, listId, cardId } = useParams();
-  const [modalOpen, setModalOpen] = useState(false);
+  const [modalOpen, setModalOpen] = useState(true);
 
   const navigate = useNavigate();
   const board = useSelector(s => s.boards.board);
@@ -14,8 +18,10 @@ export function CardDetails() {
   const card = list?.cards?.find(c => c.id === cardId);
 
   useEffect(() => {
-    setModalOpen(true);
-  }, [cardId]);
+    if (!board || board._id !== boardId) {
+      loadBoard(boardId);
+    }
+  }, [boardId, board]);
 
   function handleCloseModal() {
     setModalOpen(false);
@@ -40,7 +46,7 @@ export function CardDetails() {
   }
 
   if (!card) {
-    return null;
+    return <section className="board-container" />;
   }
 
   const cardLabels =
@@ -51,16 +57,18 @@ export function CardDetails() {
       : [];
 
   return (
-    <CardModal
-      boardId={boardId}
-      listId={list.id}
-      listTitle={list.title}
-      card={card}
-      cardLabels={cardLabels}
-      onEditCard={handleEditCard}
-      onDeleteCard={handleDeleteCard}
-      onClose={handleCloseModal}
-      isOpen={modalOpen}
-    />
+    <section className="board-container">
+      <CardModal
+        boardId={boardId}
+        listId={list.id}
+        listTitle={list.title}
+        card={card}
+        cardLabels={cardLabels}
+        onEditCard={handleEditCard}
+        onDeleteCard={handleDeleteCard}
+        onClose={handleCloseModal}
+        isOpen={modalOpen}
+      />
+    </section>
   );
 }


### PR DESCRIPTION
## 🎯 Description

Added new functionality to the **card menu** that allows users to **copy a direct URL to a specific card**. This makes it easy to share a card with others opening the link will automatically navigate to that card’s modal.

Also added a new route that enables opening the **card details modal directly**, without needing to load the board details background first. It currently loads with the same behavior as the original flow, and we can adjust or improve this experience in the future.

## 🔧 Changes

* Added “Copy Card Link” option to the card menu
* Implemented deep-linking to open a card modal via URL
* Added new route for directly loading card details
* Matched existing card modal loading behavior (customizable later)

## 📝 Notes

* Direct navigation to a card modal works even without the full board view
* Future improvements can refine UI/UX when entering from a shared link

## 🖥️ Demo

<details>
  <summary>Watch Demo Video</summary>

  <p align="center">
<video src="https://github.com/user-attachments/assets/92b6a915-f4d9-4e6a-b8ef-37f8f7811b7d" controls width="600"></video>
  </p>


</details>