### PR TITLE
Fixed the bug where menus blocked the rest of the ui #CATC-60

### DIFF
--- a/frontend/src/components/FilterMenu.jsx
+++ b/frontend/src/components/FilterMenu.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useSelector } from "react-redux";
 import FilterList from "@mui/icons-material/FilterList";
 import Autocomplete from "@mui/material/Autocomplete";
@@ -8,9 +8,9 @@ import Checkbox from "@mui/material/Checkbox";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import FormGroup from "@mui/material/FormGroup";
 import IconButton from "@mui/material/IconButton";
-import Popover from "@mui/material/Popover";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
+import { Popover } from "./Popover";
 import { useCardFilters } from "../hooks/useCardFilters";
 import {
   CURRENT_USER_ID_PLACEHOLDER,
@@ -33,10 +33,6 @@ export function FilterMenu() {
     () => getMembersFilterOptions(members),
     [members]
   );
-
-  useEffect(() => {
-    setLocalTitle(filters.title || "");
-  }, [filters.title]);
 
   function handleClearFilters() {
     setLocalTitle("");
@@ -119,11 +115,11 @@ export function FilterMenu() {
       <IconButton onClick={handleOpen}>
         <FilterList />
       </IconButton>
-
       <Popover
-        open={isOpen}
+        isOpen={isOpen}
         anchorEl={anchorEl}
         onClose={handleClose}
+        title="Filter"
         anchorOrigin={{
           vertical: "bottom",
           horizontal: "left",
@@ -132,16 +128,9 @@ export function FilterMenu() {
           vertical: "top",
           horizontal: "left",
         }}
-        slotProps={{
-          paper: {
-            sx: { width: 320, p: 2 },
-          },
-        }}
+        paperProps={{ sx: { width: 320, p: 2 } }}
       >
         <Box>
-          <Typography variant="h6" sx={{ mb: 2, textAlign: "center" }}>
-            Filter
-          </Typography>
           <Box sx={{ mb: 2 }}>
             <Typography variant="subtitle2" sx={{ mb: 1 }}>
               Title

--- a/frontend/src/components/Popover.jsx
+++ b/frontend/src/components/Popover.jsx
@@ -1,6 +1,7 @@
 import ArrowBack from "@mui/icons-material/ArrowBack";
 import Close from "@mui/icons-material/Close";
 import Box from "@mui/material/Box";
+import ClickAwayListener from "@mui/material/ClickAwayListener";
 import PopoverMUI from "@mui/material/Popover";
 import Typography from "@mui/material/Typography";
 import { SquareIconButton } from "./ui/buttons/SquareIconButton";
@@ -19,41 +20,46 @@ export function Popover({
   ...popoverProps
 }) {
   return (
-    <PopoverMUI
-      open={isOpen}
-      anchorEl={anchorEl}
-      onClose={onClose}
-      slotProps={{
-        paper: {
-          className: "popover-paper",
-          ...paperProps,
-        },
-        ...slotProps,
-      }}
-      {...popoverProps}
-    >
-      <Box className="popover-header">
-        {showBack && (
-          <Box className="popover-header-back">
-            <SquareIconButton
-              icon={<ArrowBack />}
-              aria-label="Back"
-              onClick={onBack}
-            />
-          </Box>
-        )}
-        <Typography className="popover-header-title">{title}</Typography>
-        {showClose && (
-          <Box className="popover-header-close">
-            <SquareIconButton
-              icon={<Close />}
-              aria-label="Close"
-              onClick={onClose}
-            />
-          </Box>
-        )}
-      </Box>
-      {children}
-    </PopoverMUI>
+    <ClickAwayListener onClickAway={onClose} mouseEvent="onMouseDown">
+      <PopoverMUI
+        open={isOpen}
+        anchorEl={anchorEl}
+        onClose={onClose}
+        slotProps={{
+          root: { sx: { pointerEvents: "none" } },
+          backdrop: { sx: { pointerEvents: "none" } },
+          paper: {
+            className: "popover-paper",
+            ...paperProps,
+            sx: { pointerEvents: "auto", ...paperProps.sx },
+          },
+          ...slotProps,
+        }}
+        {...popoverProps}
+      >
+        <Box className="popover-header">
+          {showBack && (
+            <Box className="popover-header-back">
+              <SquareIconButton
+                icon={<ArrowBack />}
+                aria-label="Back"
+                onClick={onBack}
+              />
+            </Box>
+          )}
+          <Typography className="popover-header-title">{title}</Typography>
+          {showClose && (
+            <Box className="popover-header-close">
+              <SquareIconButton
+                icon={<Close />}
+                aria-label="Close"
+                onClick={onClose}
+              />
+            </Box>
+          )}
+        </Box>
+        {children}
+      </PopoverMUI>
+    </ClickAwayListener>
   );
 }


### PR DESCRIPTION
## 🎯 Description

Fixed a UI issue where popover-based menus prevented interaction with the rest of the interface.
Menus now close properly when clicking anywhere outside, and no longer block buttons or other menus from being opened.

## 🔧 Changes

* Fixed popover menus blocking UI interactions
* Enabled clicking outside a menu to close it
* Added support for opening another menu while one is already open
* Ensured menus no longer override or freeze the UI while active

## 📝 Notes

This improves overall usability and prevents UI lockouts caused by overlapping or persistent menus.

## 🖥️ Demo

<details>
  <summary>Watch Demo Video</summary>

  <p align="center">
    <video src="YOUR_VIDEO_URL_HERE" controls width="600"></video>
  </p>

https://github.com/user-attachments/assets/4de43db5-996d-447d-9170-ccdd39f6b789



</details>