### PR TITLE
bugfix/CATC_129-fix-internal-server-error-when-passing-id-in-a-wrong-format

### DIFF
--- a/backend/src/middleware/error-handler.js
+++ b/backend/src/middleware/error-handler.js
@@ -11,6 +11,10 @@ function errorHandler(err, _req, res, _next) {
     error = createError(400, messages);
   }
 
+  if (err.name === "CastError") {
+    error = createError(400, `${err.path} is invalid`);
+  }
+
   if (err.name === "JsonWebTokenError") {
     error = createError(401, "Invalid token");
   }


### PR DESCRIPTION
## 🎯 Description
This PR adds explicit handling for Mongoose CastError in the error handler middleware. Requests with invalid MongoDB ObjectId values now return a 400 Bad Request with a clear message, instead of a generic internal server error.

## 🔧 Changes
- 🛠️ Added CastError handling to `backend/src/middleware/error-handler.js`
- 🧹 Returns a 400 status and a message like `"cardId is invalid"` when an invalid ObjectId is provided

## 📝 Notes
- Prevents confusing 500 errors for malformed IDs
- This fix will also handle other casting issues beside `objectId`'s which we can later catch and and handle in a more granular manner.

## 🖥️ Demo
__Example request:__
```javascript
GET /cards/123
```

__Response:__
```json
{
  "error": "cardId is invalid"
}
```

__Example request:__
```javascript
GET /lists/notAnObjectId
```

__Response:__
```json
{
  "error": "listId is invalid"
}
```
