### PR TITLE
feature/CATC_133-implement-a-basic-permissions-system-in-the-backend

### DIFF
--- a/backend/src/controllers/board-controller.js
+++ b/backend/src/controllers/board-controller.js
@@ -3,7 +3,11 @@ import createError from "http-errors";
 
 export async function createBoard(req, res) {
   try {
-    const { title, description, owner } = req.body;
+    const { title, description } = req.body;
+    const owner = {
+      userId: req.currentUser._id,
+      username: req.currentUser.username,
+    };
     const board = await boardService.createBoard({ title, description, owner });
     res.status(201).json({ board });
   } catch (err) {

--- a/backend/src/middleware/authorize.js
+++ b/backend/src/middleware/authorize.js
@@ -1,0 +1,80 @@
+import createError from "http-errors";
+import * as permissions from "../services/permissions/index.js";
+
+export function authorize(permissionCheck) {
+  return async (req, _res, next) => {
+    try {
+      const userId = req.currentUser._id;
+      const hasPermission = await permissionCheck(req, userId);
+
+      if (!hasPermission) {
+        return next(
+          createError(403, "You do not have permission to perform this action")
+        );
+      }
+
+      next();
+    } catch (error) {
+      next(error);
+    }
+  };
+}
+
+export function canViewBoard() {
+  return authorize(async (req, userId) => {
+    return await permissions.board.canViewBoard(userId, req.params.id);
+  });
+}
+
+export function canManageBoard() {
+  return authorize(async (req, userId) => {
+    return await permissions.board.canManageBoard(userId, req.params.id);
+  });
+}
+
+export function canModifyBoardContent() {
+  return authorize(async (req, userId) => {
+    return await permissions.board.canModifyBoardContent(userId, req.params.id);
+  });
+}
+
+export function canModifyList() {
+  return authorize(async (req, userId) => {
+    return await permissions.list.canModifyList(userId, req.params.id);
+  });
+}
+
+export function canModifyCard() {
+  return authorize(async (req, userId) => {
+    return await permissions.card.canModifyCard(userId, req.params.id);
+  });
+}
+
+export function canCreateBoard() {
+  return authorize(async (req, userId) => {
+    return true;
+  });
+}
+
+export function canCreateList() {
+  return authorize(async (req, userId) => {
+    const boardId =
+      req.body.boardId ||
+      req.query.boardId ||
+      (req.body.list && req.body.list.board);
+    if (!boardId) return false;
+    return await permissions.board.canModifyBoardContent(userId, boardId);
+  });
+}
+
+export function canCreateCard() {
+  return authorize(async (req, userId) => {
+    const boardId =
+      req.body.boardId ||
+      req.query.boardId ||
+      (req.body.card && req.body.card.board) ||
+      (req.body.list && req.body.list.board);
+    if (!boardId) return false;
+    return await permissions.board.canModifyBoardContent(userId, boardId);
+  });
+}

--- a/backend/src/routes/boards.js
+++ b/backend/src/routes/boards.js
@@ -12,29 +12,28 @@ import {
   deleteBoardLabel,
 } from "../controllers/board-controller.js";
 import { authenticate } from "../middleware/authenticate.js";
-import { loadBoard } from "../middleware/load-board.js";
+import { canManageBoard, canCreateBoard } from "../middleware/authorize.js";
 
 const router = express.Router();
 
-// Public routes
 router.get("/", getAllBoards);
 router.get("/:id", getBoardById);
 router.get("/:id/full", getFullBoardById);
-
-// Protected routes
-const protectedRouter = express.Router();
-protectedRouter.use(authenticate);
-protectedRouter.post("/", createBoard);
-
-// Routes with authorization and other middleware
-protectedRouter.put("/:id", loadBoard, updateBoard);
-protectedRouter.delete("/:id", loadBoard, deleteBoard);
-
-protectedRouter.get("/:id/labels", loadBoard, getBoardLabels);
-protectedRouter.post("/:id/labels", loadBoard, addBoardLabel);
-protectedRouter.put("/:id/labels/:labelId", loadBoard, updateBoardLabel);
-protectedRouter.delete("/:id/labels/:labelId", loadBoard, deleteBoardLabel);
-
-router.use("/", protectedRouter);
-
+router.post("/", authenticate, canCreateBoard(), createBoard);
+router.put("/:id", authenticate, canManageBoard(), updateBoard);
+router.delete("/:id", authenticate, canManageBoard(), deleteBoard);
+router.get("/:id/labels", authenticate, canManageBoard(), getBoardLabels);
+router.post("/:id/labels", authenticate, canManageBoard(), addBoardLabel);
+router.put(
+  "/:id/labels/:labelId",
+  authenticate,
+  canManageBoard(),
+  updateBoardLabel
+);
+router.delete(
+  "/:id/labels/:labelId",
+  authenticate,
+  canManageBoard(),
+  deleteBoardLabel
+);
 export default router;

--- a/backend/src/routes/cards.js
+++ b/backend/src/routes/cards.js
@@ -10,21 +10,16 @@ import {
   updateLabels,
 } from "../controllers/card-controller.js";
 import { authenticate } from "../middleware/authenticate.js";
+import { canModifyCard, canCreateCard } from "../middleware/authorize.js";
 
 const router = express.Router();
 
 router.get("/", getAllCards);
 router.get("/:id", getCardById);
-
-const protectedRouter = express.Router();
-protectedRouter.use(authenticate);
-
-protectedRouter.post("/", createCard);
-protectedRouter.put("/:id", updateCard);
-protectedRouter.put("/:id/labels", updateLabels);
-protectedRouter.delete("/:id", deleteCard);
-
-router.use("/", protectedRouter);
+router.post("/", authenticate, canCreateCard(), createCard);
+router.put("/:id", authenticate, canModifyCard(), updateCard);
+router.delete("/:id", authenticate, canModifyCard(), deleteCard);
+router.put("/:id/labels", authenticate, canModifyCard(), updateLabels);
 
 // router.get("/label/:labelId", getCardsByLabel);
 // router.get("/assigned/:userId", getCardsByAssignedUser);

--- a/backend/src/routes/list.js
+++ b/backend/src/routes/list.js
@@ -9,19 +9,16 @@ import {
   deleteList,
 } from "../controllers/list-controller.js";
 import { authenticate } from "../middleware/authenticate.js";
+import { canModifyList, canCreateList } from "../middleware/authorize.js";
 
 const router = express.Router();
 
-const protectedRouter = express.Router();
-protectedRouter.use(authenticate);
-
 router.get("/", getListsByBoardId);
-protectedRouter.get("/:id", getListById);
-protectedRouter.post("/", createList);
-protectedRouter.put("/:id", updateList);
-protectedRouter.put("/:id/move", moveList);
-protectedRouter.put("/:id/archive", archiveList);
-protectedRouter.delete("/:id", deleteList);
+router.get("/:id", getListById);
+router.post("/", authenticate, canCreateList(), createList);
+router.put("/:id", authenticate, canModifyList(), updateList);
+router.put("/:id/move", authenticate, canModifyList(), moveList);
+router.put("/:id/archive", authenticate, canModifyList(), archiveList);
+router.delete("/:id", authenticate, canModifyList(), deleteList);
 
-router.use(protectedRouter);
 export default router;

--- a/backend/src/services/permissions/board.js
+++ b/backend/src/services/permissions/board.js
@@ -1,0 +1,36 @@
+import { Board } from "../../models/Board.js";
+import { isMemberOfArray, isOwner } from "./helpers.js";
+
+export async function canViewBoard(userId, boardId) {
+  const board = await Board.findById(boardId);
+  if (!board) return false;
+
+  return (
+    isOwner(userId, board.owner.userId) ||
+    isMemberOfArray(userId, board.members)
+  );
+}
+
+export async function canManageBoard(userId, boardId) {
+  const board = await Board.findById(boardId);
+  if (!board) return false;
+
+  return isOwner(userId, board.owner.userId);
+}
+
+export async function canModifyBoardContent(userId, boardId) {
+  const board = await Board.findById(boardId);
+  if (!board) return false;
+
+  return (
+    isOwner(userId, board.owner.userId) ||
+    isMemberOfArray(userId, board.members)
+  );
+}
+
+export async function isBoardOwner(userId, boardId) {
+  const board = await Board.findById(boardId);
+  if (!board) return false;
+
+  return isOwner(userId, board.owner.userId);
+}

--- a/backend/src/services/permissions/card.js
+++ b/backend/src/services/permissions/card.js
@@ -1,0 +1,16 @@
+import { Card } from "../../models/Card.js";
+import { canModifyBoardContent, canViewBoard } from "./board.js";
+
+export async function canModifyCard(userId, cardId) {
+  const card = await Card.findById(cardId);
+  if (!card) return false;
+
+  return await canModifyBoardContent(userId, card.boardId);
+}
+
+export async function canViewCard(userId, cardId) {
+  const card = await Card.findById(cardId);
+  if (!card) return false;
+
+  return await canViewBoard(userId, card.boardId);
+}

--- a/backend/src/services/permissions/helpers.js
+++ b/backend/src/services/permissions/helpers.js
@@ -1,0 +1,7 @@
+export function isMemberOfArray(userId, members) {
+  return members.some(member => member.userId.toString() === userId.toString());
+}
+
+export function isOwner(userId, ownerId) {
+  return ownerId.toString() === userId.toString();
+}

--- a/backend/src/services/permissions/index.js
+++ b/backend/src/services/permissions/index.js
@@ -1,0 +1,3 @@
+export * as board from "./board.js";
+export * as list from "./list.js";
+export * as card from "./card.js";

--- a/backend/src/services/permissions/list.js
+++ b/backend/src/services/permissions/list.js
@@ -1,0 +1,16 @@
+import { List } from "../../models/List.js";
+import { canModifyBoardContent, canViewBoard } from "./board.js";
+
+export async function canModifyList(userId, listId) {
+  const list = await List.findById(listId);
+  if (!list) return false;
+
+  return await canModifyBoardContent(userId, list.boardId);
+}
+
+export async function canViewList(userId, listId) {
+  const list = await List.findById(listId);
+  if (!list) return false;
+
+  return await canViewBoard(userId, list.boardId);
+}


### PR DESCRIPTION
## 🎯 Description

Implemented a  backend permissions system, providing access control for boards, lists, and cards.

---

## 🔧 Changes

- 🔐 **Authorization Middleware**: Created `authorize.js` middleware with permission check functions for different resource types and access levels
- 🛡️ **Permission Service Modules**: Implemented modular permission system with separate handlers for boards, lists, and cards
- 🔗 **Route Protection Integration**: Added permission checks to board, list, and card routes to enforce access control
- 👥 **Role-Based Access**: Implemented owner/member permission logic allowing owners full control and members content modification access
- 📋 **Helper Functions**: Created utility functions for permission validation and user role checking

---

## 📝 Notes

- This is a backend-only implementation that provides the foundation for permissions
- Permission system supports three levels: view, modify content, and manage
- Board owners have full access, while members can modify board content
