### PR TITLE
bugfix/fix-missing-attributes-un-full-board-details

### DIFF
--- a/backend/src/models/Board.js
+++ b/backend/src/models/Board.js
@@ -54,6 +54,8 @@ const boardSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
+boardSchema.set("toJSON", { virtuals: true });
+
 boardSchema.virtual("lists", {
   ref: "List",
   localField: "_id",

--- a/backend/src/models/List.js
+++ b/backend/src/models/List.js
@@ -32,6 +32,8 @@ const listSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
+listSchema.set("toJSON", { virtuals: true });
+
 listSchema.virtual("cards", {
   ref: "Card",
   localField: "_id",

--- a/backend/src/services/board-service.js
+++ b/backend/src/services/board-service.js
@@ -13,16 +13,14 @@ export async function getBoardById(id) {
 }
 
 export async function getFullBoardById(id) {
-  const board = await Board.findById(id)
-    .populate({
-      path: "lists",
+  const board = await Board.findById(id).populate({
+    path: "lists",
+    options: { sort: { position: 1 } },
+    populate: {
+      path: "cards",
       options: { sort: { position: 1 } },
-      populate: {
-        path: "cards",
-        options: { sort: { position: 1 } },
-      },
-    })
-    .lean();
+    },
+  });
   return board;
 }
 


### PR DESCRIPTION
This pr fixes an issue where some properties that contain subdocuments array, and for some reason are empty/undefined, they don't appear in the response of the `getFullBoardDetails` action. This is caused by using lean, which removes virtual properties. There is also possible issue with this being nested virtual properties: boards -> lists -> cards.