### PR TITLE
feature/CATC_110-implemnet-card-dates

### DIFF
--- a/backend/src/db/migrations/2025.12.06T16.26.58.seed-card-dates.js
+++ b/backend/src/db/migrations/2025.12.06T16.26.58.seed-card-dates.js
@@ -1,0 +1,59 @@
+export const up = async ({ context }) => {
+  const dateUpdates = [
+    {
+      titles: [
+        "extend next-generation lifetime value",
+        "deploy transparent architectures",
+      ],
+      dueDate: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000), // 2 days from now
+      startDate: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000), // 1 day ago
+    },
+    {
+      titles: [
+        "syndicate intuitive architectures",
+        "grow cross-media supply-chains",
+      ],
+      dueDate: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000), // 3 days from now
+      startDate: null,
+    },
+    {
+      titles: ["embrace distributed paradigms"],
+      dueDate: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000), // 2 days ago
+      startDate: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000), // 5 days ago
+    },
+    {
+      titles: [
+        "monetize compelling smart contracts",
+        "optimize holistic communities",
+      ],
+      startDate: new Date(Date.now() + 1 * 24 * 60 * 60 * 1000), // starts tomorrow
+      dueDate: null,
+    },
+    {
+      titles: ["incubate cross-platform platforms", "engage immersive ROI"],
+      startDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 1 week from now
+      dueDate: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000), // 2 weeks from now
+    },
+  ];
+
+  for (const update of dateUpdates) {
+    await context.collection("cards").updateMany(
+      { title: { $in: update.titles } },
+      {
+        $set: {
+          startDate: update.startDate,
+          dueDate: update.dueDate,
+        },
+      }
+    );
+  }
+};
+
+export const down = async ({ context }) => {
+  await context.collection("cards").updateMany(
+    {},
+    {
+      $unset: { startDate: 1, dueDate: 1 },
+    }
+  );
+};

--- a/backend/src/models/Card.js
+++ b/backend/src/models/Card.js
@@ -80,6 +80,26 @@ const cardSchema = new mongoose.Schema(
       type: Date,
       default: null,
     },
+    startDate: {
+      type: Date,
+      default: null,
+      validate: {
+        validator: function (startDate) {
+          return !startDate || !this.dueDate || startDate <= this.dueDate;
+        },
+        message: "Start date must be before or equal to due date",
+      },
+    },
+    dueDate: {
+      type: Date,
+      default: null,
+      validate: {
+        validator: function (dueDate) {
+          return !dueDate || !this.startDate || this.startDate <= dueDate;
+        },
+        message: "Due date must be after or equal to start date",
+      },
+    },
     comments: [commentSchema],
   },
   { timestamps: true }

--- a/backend/src/models/Card.js
+++ b/backend/src/models/Card.js
@@ -83,26 +83,59 @@ const cardSchema = new mongoose.Schema(
     startDate: {
       type: Date,
       default: null,
-      validate: {
-        validator: function (startDate) {
-          return !startDate || !this.dueDate || startDate <= this.dueDate;
-        },
-        message: "Start date must be before or equal to due date",
-      },
     },
     dueDate: {
       type: Date,
       default: null,
-      validate: {
-        validator: function (dueDate) {
-          return !dueDate || !this.startDate || this.startDate <= dueDate;
-        },
-        message: "Due date must be after or equal to start date",
-      },
     },
     comments: [commentSchema],
   },
   { timestamps: true }
 );
+
+cardSchema.pre("save", function (next) {
+  const error = validateDateOrder(this.startDate, this.dueDate);
+  if (error) return next(error);
+  next();
+});
+
+// Validation for .findByIdAndUpdate() and .findOneAndUpdate()
+cardSchema.pre("findOneAndUpdate", async function (next) {
+  const update = this.getUpdate();
+
+  const startDateUpdate = update.$set?.startDate || update.startDate;
+  const dueDateUpdate = update.$set?.dueDate || update.dueDate;
+
+  if (startDateUpdate !== undefined || dueDateUpdate !== undefined) {
+    const doc = await this.model.findOne(this.getFilter());
+    if (!doc) return next();
+
+    const startDate = startDateUpdate
+      ? new Date(startDateUpdate)
+      : doc.startDate;
+    const dueDate = dueDateUpdate ? new Date(dueDateUpdate) : doc.dueDate;
+
+    const error = validateDateOrder(startDate, dueDate);
+    if (error) return next(error);
+  }
+
+  next();
+});
+
+function validateDateOrder(startDate, dueDate) {
+  if (startDate && dueDate && startDate > dueDate) {
+    const error = new mongoose.Error.ValidationError();
+    error.addError(
+      "dueDate",
+      new mongoose.Error.ValidatorError({
+        path: "dueDate",
+        message: "Due date must be after or equal to start date",
+        value: dueDate,
+      })
+    );
+    return error;
+  }
+  return null;
+}
 
 export const Card = mongoose.model("Card", cardSchema);

--- a/backend/src/services/card-service.js
+++ b/backend/src/services/card-service.js
@@ -32,10 +32,10 @@ export async function getCardById(id) {
 }
 
 export async function updateCard(id, updateData) {
-  const { title, description } = updateData;
+  const { title, description, startDate, dueDate } = updateData;
   return await Card.findByIdAndUpdate(
     id,
-    { title, description },
+    { title, description, startDate, dueDate },
     {
       new: true,
       runValidators: true,


### PR DESCRIPTION
## 🎯 Description
Adds startDate and dueDate fields to cards with robust validation, following Trello's date management pattern.

## 🔧 Changes
### 📅 __Card Model Enhancement__
- Added optional `startDate` and `dueDate` Date fields
- Implemented validation ensuring startDate ≤ dueDate
- Database-level validation with proper error messages

### 🔄 __Service Layer Updates__
- Enhanced `updateCard` to handle date parameters
- Automatic validation through MongoDB validators

### 🗄️ __Database Migration__
- Seeded realistic date data to existing cards
- Covers various date scenarios

## 📝 Notes
- __Validation__: startDate must be ≤ dueDate, both fields optional
- __API__: Uses existing `PUT /api/cards/:id` endpoint
