### PR TITLE
feature/CATC-124-implement-move-card-in-the-backend

### DIFF
--- a/backend/src/controllers/card-controller.js
+++ b/backend/src/controllers/card-controller.js
@@ -34,6 +34,19 @@ export async function deleteCard(req, res) {
   res.status(204).send();
 }
 
+export async function moveCard(req, res) {
+  const { listId, boardId, targetIndex } = req.body;
+  const card = await cardService.moveCard(
+    req.params.id,
+    listId,
+    boardId,
+    targetIndex
+  );
+  if (!card) throw createError(404, "Card not found");
+
+  res.status(200).json({ card });
+}
+
 export async function getCardsByLabel(req, res) {
   const { labelId } = req.params;
   const cards = await Card.find({ labels: labelId }).sort({ createdAt: -1 });

--- a/backend/src/models/Card.js
+++ b/backend/src/models/Card.js
@@ -138,4 +138,6 @@ function validateDateOrder(startDate, dueDate) {
   return null;
 }
 
+cardSchema.index({ listId: 1, position: 1 }, { unique: true });
+
 export const Card = mongoose.model("Card", cardSchema);

--- a/backend/src/routes/cards.js
+++ b/backend/src/routes/cards.js
@@ -5,6 +5,7 @@ import {
   getCardById,
   updateCard,
   deleteCard,
+  moveCard,
   getCardsByLabel,
   getCardsByAssignedUser,
   updateLabels,
@@ -25,6 +26,7 @@ router.get("/:id", getCardById);
 router.post("/", authenticate, canCreateCard(), createCard);
 router.put("/:id", authenticate, canModifyCard(), updateCard);
 router.delete("/:id", authenticate, canModifyCard(), deleteCard);
+router.put("/:id/move", authenticate, canModifyCard(), moveCard);
 router.put("/:id/labels", authenticate, canModifyCard(), updateLabels);
 router.post("/:cardId/comments", authenticate, canModifyCard(), addComment);
 router.put(


### PR DESCRIPTION
## 🎯 Description
Implemented card movement functionality and position validation to prevent corrupt data due to duplicate card positions within the same list.

## 🔧 Changes
- 🔄 **moveCard Feature**: Added complete card movement logic with cross-board support and position management
- 🔒 **Database Index**: Added composite unique index `{listId: 1, position: 1}` to prevent duplicate positions
- 📍 **Fractional Indexing**: Uses position-service for consistent card ordering

## 📝 Notes
- **Cross-Board Support**: Cards can be moved between lists on same board and across different boards
- **Race Condition Protection**: Database-level constraints prevent duplicate positions during concurrent operations
- **Validation**: Board/list validation ensures cards are only moved to valid destinations

### ⚠️ Technical Debt

**Race Condition in createCard**: Concurrent `createCard` requests can fail due to unhandled position conflicts. This occurs when multiple requests calculate the same position simultaneously, causing database constraint violations. The current database index prevents duplicates but doesn't provide graceful handling for failed requests.

**Example Race Condition**:

```
Request A: GET cards from list → finds 3 cards → calculates position "a0" → creates card
Request B: GET cards from list → finds 3 cards → calculates position "a0" → FAILS (duplicate)
Request C: GET cards from list → finds 4 cards → calculates position "a1" → creates card
```

**Future Ticket**: Will open ticket to implement retry logic with exponential backoff for concurrent create operations (both cards and lists).

