### PR TITLE
feature/CATC-142-implement-copy-card-in-the-backend

### DIFF
--- a/backend/src/controllers/card-controller.js
+++ b/backend/src/controllers/card-controller.js
@@ -118,3 +118,10 @@ export async function removeAssignee(req, res) {
 
   res.status(200).json({ card });
 }
+
+export async function copyCard(req, res) {
+  const { id } = req.params;
+  const copyOptions = req.body;
+  const copiedCard = await cardService.copyCard(id, copyOptions);
+  res.status(201).json({ card: copiedCard });
+}

--- a/backend/src/routes/cards.js
+++ b/backend/src/routes/cards.js
@@ -15,6 +15,7 @@ import {
   getComments,
   addAssignee,
   removeAssignee,
+  copyCard,
 } from "../controllers/card-controller.js";
 import { authenticate } from "../middleware/authenticate.js";
 import { canModifyCard, canCreateCard } from "../middleware/authorize.js";
@@ -53,5 +54,7 @@ router.delete(
   canModifyCard(),
   removeAssignee
 );
+
+router.post("/:id/copy", authenticate, canModifyCard(), copyCard);
 
 export default router;

--- a/backend/src/services/permissions/card.js
+++ b/backend/src/services/permissions/card.js
@@ -1,16 +1,17 @@
 import { Card } from "../../models/Card.js";
 import { canModifyBoardContent, canViewBoard } from "./board.js";
+import createError from "http-errors";
 
 export async function canModifyCard(userId, cardId) {
   const card = await Card.findById(cardId);
-  if (!card) return false;
+  if (!card) throw createError(404, "Card not found");
 
   return await canModifyBoardContent(userId, card.boardId);
 }
 
 export async function canViewCard(userId, cardId) {
   const card = await Card.findById(cardId);
-  if (!card) return false;
+  if (!card) throw createError(404, "Card not found");
 
   return await canViewBoard(userId, card.boardId);
 }


### PR DESCRIPTION
## 🎯 Description
Implements backend functionality for copying cards within the same list, to different lists, or across boards, with flexible options for what data to include.

## 🔧 Changes
- ✨ Added `POST /cards/:id/copy` endpoint with authorization middleware
- 🔧 Implemented `copyCard` service with support for:
  - Optional copying of labels, assignee's, comments, and dates
  - Custom title override
  - Target list and board specification
  - Target position/index control

__Key Implementation Details:__
- Validates target board/list existence for cross-board copies
- Filters assignee's to ensure they're valid users and board members on target board
- Uses existing position service for proper card placement
- Preserves comment authorship and metadata when copying

## 📝 Notes
- When copying across boards, only assignee's who are members of the target board will be copied
- Comments are copied with original author information but marked as new (not edited)
- Position calculation ensures the copied card is placed correctly in the target list
