### PR TITLE
feature/CATC_144-connect-frontend-with-backend

### DIFF
--- a/backend/src/controllers/board-controller.js
+++ b/backend/src/controllers/board-controller.js
@@ -102,5 +102,5 @@ export async function deleteBoardLabel(req, res) {
     req.params.labelId
   );
   if (!board) throw createError(404, "Label not found");
-  res.json({ labels: board.labels });
+  res.status(204).send();
 }

--- a/backend/src/controllers/board-controller.js
+++ b/backend/src/controllers/board-controller.js
@@ -78,11 +78,11 @@ export async function getBoardLabels(req, res) {
 
 export async function addBoardLabel(req, res) {
   const { title, color } = req.body;
-  const board = await boardService.addLabelToBoard(req.params.id, {
+  const label = await boardService.addLabelToBoard(req.params.id, {
     title,
     color,
   });
-  res.status(201).json({ labels: board.labels });
+  res.status(201).json({ label });
 }
 
 export async function updateBoardLabel(req, res) {

--- a/backend/src/controllers/board-controller.js
+++ b/backend/src/controllers/board-controller.js
@@ -87,13 +87,13 @@ export async function addBoardLabel(req, res) {
 
 export async function updateBoardLabel(req, res) {
   const { title, color } = req.body;
-  const board = await boardService.updateLabelInBoard(
+  const updatedLabel = await boardService.updateLabelInBoard(
     req.params.id,
     req.params.labelId,
     { title, color }
   );
-  if (!board) throw createError(404, "Label not found");
-  res.json({ labels: board.labels });
+  if (!updatedLabel) throw createError(404, "Label not found");
+  res.json({ label: updatedLabel });
 }
 
 export async function deleteBoardLabel(req, res) {

--- a/backend/src/services/board-service.js
+++ b/backend/src/services/board-service.js
@@ -42,11 +42,12 @@ export async function getBoardLabels(boardId) {
 }
 
 export async function addLabelToBoard(boardId, labelData) {
-  return await Board.findByIdAndUpdate(
+  const board = await Board.findByIdAndUpdate(
     boardId,
     { $push: { labels: labelData } },
     { new: true, runValidators: true }
   );
+  return board.labels.at(-1);
 }
 
 export async function updateLabelInBoard(boardId, labelId, labelData) {

--- a/backend/src/services/board-service.js
+++ b/backend/src/services/board-service.js
@@ -51,7 +51,7 @@ export async function addLabelToBoard(boardId, labelData) {
 }
 
 export async function updateLabelInBoard(boardId, labelId, labelData) {
-  return await Board.findOneAndUpdate(
+  const board = await Board.findOneAndUpdate(
     { _id: boardId, "labels._id": labelId },
     {
       $set: {
@@ -61,6 +61,7 @@ export async function updateLabelInBoard(boardId, labelId, labelData) {
     },
     { new: true, runValidators: true }
   );
+  return board.labels.id(labelId);
 }
 
 export async function removeLabelFromBoard(boardId, labelId) {

--- a/backend/src/services/list-service.js
+++ b/backend/src/services/list-service.js
@@ -4,7 +4,20 @@ import { getBoardById } from "./board-service.js";
 import createHttpError from "http-errors";
 
 export async function createList(listData) {
-  return new List(listData).save();
+  const { boardId, title, targetIndex } = listData;
+  let position;
+  if (!targetIndex) {
+    const lists = await List.find({ boardId }).sort({ position: 1 });
+    position = calculateNewPosition(lists, lists.length);
+  } else {
+    // TODO: implement inserting at specific index
+  }
+  const list = await List.create({
+    boardId,
+    title,
+    position,
+  });
+  return list;
 }
 
 export async function getListById(id) {

--- a/backend/src/services/permissions/board.js
+++ b/backend/src/services/permissions/board.js
@@ -15,7 +15,10 @@ export async function canManageBoard(userId, boardId) {
   const board = await Board.findById(boardId);
   if (!board) return false;
 
-  return isOwner(userId, board.owner.userId);
+  return (
+    isOwner(userId, board.owner.userId) ||
+    isMemberOfArray(userId, board.members)
+  );
 }
 
 export async function canModifyBoardContent(userId, boardId) {

--- a/frontend/src/components/AddCardForm.jsx
+++ b/frontend/src/components/AddCardForm.jsx
@@ -3,7 +3,7 @@ import { useSelector } from "react-redux";
 import CloseIcon from "@mui/icons-material/Close";
 import Button from "@mui/material/Button";
 import IconButton from "@mui/material/IconButton";
-import { boardService } from "../services/board/board-service-local";
+import { boardService } from "../services/board";
 import { addCard } from "../store/actions/board-actions";
 
 export function AddCardForm({

--- a/frontend/src/components/ListActionsMenu.jsx
+++ b/frontend/src/components/ListActionsMenu.jsx
@@ -53,8 +53,8 @@ export function ListActionsMenu({
     onClose();
   }
 
-  function handleCopyList(listId, newName) {
-    onCopyList(listId, newName);
+  function handleCopyList(listId, copyOptions = {}) {
+    onCopyList(listId, copyOptions);
     setActiveAction(null);
     onClose();
   }
@@ -94,7 +94,12 @@ export function ListActionsMenu({
       {activeAction === "copy" ? (
         <CopyListForm
           initialValue={list.title}
-          onCopy={newName => handleCopyList(list._id, newName)}
+          onCopy={newTitle =>
+            handleCopyList(list._id, {
+              title: newTitle,
+              targetIndex: activeListIndex + 1,
+            })
+          }
           onCancel={handleCopyCancel}
         />
       ) : activeAction === "moveAll" ? (

--- a/frontend/src/components/MoveListForm.jsx
+++ b/frontend/src/components/MoveListForm.jsx
@@ -3,10 +3,11 @@ import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import { ActionButton } from "./ui/buttons/ActionButton";
 import { CustomAutoComplete } from "./ui/CustomAutoComplete";
+import { useEffect, useState } from "react";
+import { boardService } from "../services/board";
 
 export function MoveListForm({
   currentBoard,
-  boards,
   activeListIndex,
   onSubmit,
   onCancel,
@@ -16,7 +17,32 @@ export function MoveListForm({
     boardId: defaultBoardId,
     position: activeListIndex || 0,
   });
-  const selectedBoard = boards.find(b => b._id === values.boardId);
+  const [boards, setBoards] = useState([]);
+  const [selectedBoardLists, setSelectedBoardLists] = useState([]);
+
+  useEffect(() => {
+    (async function () {
+      try {
+        const boardNames = await boardService.getBoardPreviews();
+        setBoards(boardNames);
+      } catch (error) {
+        console.error("Error loading boards:", error);
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    (async function () {
+      if (!values.boardId) return;
+      try {
+        const lists = await boardService.getBoardListPreviews(values.boardId);
+        setSelectedBoardLists(lists);
+      } catch (error) {
+        console.error("Error loading lists:", error);
+        setSelectedBoardLists([]);
+      }
+    })();
+  }, [values.boardId]);
 
   // handle position when board changes
   function handleBoardChange(boardId) {
@@ -82,16 +108,13 @@ export function MoveListForm({
             label="Position"
             value={values.position}
             onChange={handlePositionChange}
-            disabled={!selectedBoard.lists || selectedBoard.lists.length === 0}
+            disabled={!selectedBoardLists || selectedBoardLists.length === 0}
             options={
-              selectedBoard.lists && selectedBoard.lists.length > 0
-                ? Array.from(
-                    { length: selectedBoard.lists.length },
-                    (_, i) => ({
-                      _id: i,
-                      title: (i + 1).toString(),
-                    })
-                  )
+              selectedBoardLists && selectedBoardLists.length > 0
+                ? Array.from({ length: selectedBoardLists.length }, (_, i) => ({
+                    _id: i,
+                    title: (i + 1).toString(),
+                  }))
                 : []
             }
           />

--- a/frontend/src/pages/BoardDetails.jsx
+++ b/frontend/src/pages/BoardDetails.jsx
@@ -68,9 +68,9 @@ export function BoardDetails() {
     setSearchParams(filterBy);
   }, [filters, setSearchParams]);
 
-  async function onCopyList(listId, newName) {
+  async function onCopyList(listId, copyOptions) {
     try {
-      await copyList(board._id, listId, newName);
+      await copyList(listId, copyOptions);
     } catch (error) {
       console.error("List copy failed:", error);
     }

--- a/frontend/src/services/auth/auth-service-remote.js
+++ b/frontend/src/services/auth/auth-service-remote.js
@@ -1,14 +1,31 @@
+import { httpService } from "../http-service";
+
+const CURRENT_USER_SESSION_KEY = "currentUser";
+
 export const authService = {
   signup,
   login,
-  setCurrentUserInSession,
-  getCurrentUserFromSession,
+  logout,
+  getSession,
 };
 
-export async function signup(userData) {}
+async function signup(userData) {
+  const data = await httpService.post("auth/signup", userData);
+  const user = data.user;
+  return user;
+}
 
-export async function login(credentials) {}
+async function login(credentials) {
+  const data = await httpService.post("auth/login", credentials);
+  const user = data.user;
+  return user;
+}
 
-export function setCurrentUserInSession(user) {}
+async function logout() {
+  await httpService.post("auth/logout");
+}
 
-export function getCurrentUserFromSession() {}
+async function getSession() {
+  const data = await httpService.get("auth/session");
+  return data.user;
+}

--- a/frontend/src/services/board/board-service-remote.js
+++ b/frontend/src/services/board/board-service-remote.js
@@ -11,7 +11,7 @@ export const boardService = {
   addCard,
   editCard,
   deleteCard,
-  // copyCard,
+  copyCard,
   // moveCard,
   getEmptyList,
   createList,
@@ -92,29 +92,28 @@ async function deleteCard(boardId, cardId, listId) {
   return { cardId };
 }
 
-// async function copyCard(copyData, card) {
-//   const {
-//     destinationBoardId,
-//     destinationListId,
-//     keepLabels,
-//     keepMembers,
-//     position,
-//     title,
-//   } = copyData;
+async function copyCard(copyData, card) {
+  const {
+    destinationBoardId,
+    destinationListId,
+    keepLabels,
+    keepMembers,
+    title,
+    description,
+  } = copyData;
 
-//   const clonedCard = {
-//     title,
-//     description: card.description,
-//     listId: destinationListId,
-//     boardId: destinationBoardId,
-//     assignedTo: keepMembers ? card.assignedTo : [],
-//     labelIds: keepLabels ? card.labelIds : [],
-//     position,
-//   };
+  const copyOptions = {
+    targetBoardId: destinationBoardId,
+    targetListId: destinationListId,
+    title,
+    description: description ?? card.description,
+    copyMembers: keepMembers ?? false,
+    copyLabels: keepLabels ?? false,
+  };
 
-//   const data = await httpService.post("cards", clonedCard);
-//   return data.card;
-// }
+  const data = await httpService.post(`cards/${card._id}/copy`, copyOptions);
+  return data.card;
+}
 
 // async function moveCard(moveData, card) {
 //   const { destinationListId, destinationBoardId, position } = moveData;

--- a/frontend/src/services/board/board-service-remote.js
+++ b/frontend/src/services/board/board-service-remote.js
@@ -22,7 +22,7 @@ export const boardService = {
   // moveAllCards,
   // archiveAllCardsInList,
   updateCardLabels,
-  // createLabel,
+  createLabel,
   // editLabel,
   // deleteLabel,
   // getBoardPreviews,
@@ -242,10 +242,10 @@ async function updateCardLabels(_boardId, _listId, cardId, updatedCardLabels) {
   return updatedCardLabels;
 }
 
-// async function createLabel(boardId, label) {
-//   const data = await httpService.post(`boards/${boardId}/labels`, label);
-//   return data.labels;
-// }
+async function createLabel(boardId, label) {
+  const data = await httpService.post(`boards/${boardId}/labels`, label);
+  return data.label;
+}
 
 // async function editLabel(boardId, label) {
 //   const data = await httpService.put(

--- a/frontend/src/services/board/board-service-remote.js
+++ b/frontend/src/services/board/board-service-remote.js
@@ -7,7 +7,7 @@ export const boardService = {
   // remove,
   // save,
   // updateBoard,
-  // getEmptyCard,
+  getEmptyCard,
   addCard,
   editCard,
   deleteCard,
@@ -65,12 +65,9 @@ async function getFullById(boardId) {
 
 function getEmptyCard() {
   return {
-    _id: crypto.randomUUID(),
     title: "",
     description: "",
     labelIds: [],
-    createdAt: null,
-    archivedAt: null,
   };
 }
 

--- a/frontend/src/services/board/board-service-remote.js
+++ b/frontend/src/services/board/board-service-remote.js
@@ -4,52 +4,275 @@ export const boardService = {
   query,
   getById,
   getFullById,
+  // remove,
+  // save,
+  // updateBoard,
+  // getEmptyCard,
+  addCard,
+  // editCard,
+  // deleteCard,
+  // copyCard,
+  // moveCard,
+  // getEmptyList,
+  // createList,
+  // moveList,
+  // copyList,
+  // archiveList,
+  // unarchiveList,
+  // moveAllCards,
+  // archiveAllCardsInList,
   updateCardLabels,
+  // createLabel,
+  // editLabel,
+  // deleteLabel,
+  // getBoardPreviews,
+  // getBoardListPreviews,
 };
 
-export async function query() {
-  try {
-    const data = await httpService.get("boards");
-    console.log("data query", data);
-    return data.boards;
-  } catch (error) {
-    console.error("Cannot get boards:", error);
-    throw error;
-  }
+async function query() {
+  const data = await httpService.get("boards");
+  return data.boards;
 }
 
 async function getById(boardId) {
-  try {
-    const data = await httpService.get(`boards/${boardId}`);
-    return data.board;
-  } catch (error) {
-    console.error("Cannot get board:", error);
-
-    throw error;
-  }
+  const data = await httpService.get(`boards/${boardId}`);
+  return data.board;
 }
 
 async function getFullById(boardId) {
-  try {
-    const data = await httpService.get(`boards/${boardId}/full`);
-    console.log("data getFullById", data);
-    return data.board;
-  } catch (error) {
-    console.error("Cannot get full board:", error);
-    throw error;
-  }
+  const data = await httpService.get(`boards/${boardId}/full`);
+  return data.board;
 }
+
+// async function remove(boardId) {
+//   await httpService.delete(`boards/${boardId}`);
+// }
+
+// async function save(board) {
+//   if (board._id) {
+//     const data = await httpService.put(`boards/${board._id}`, board);
+//     return data.board;
+//   } else {
+//     const data = await httpService.post("boards", board);
+//     return data.board;
+//   }
+// }
+
+// async function updateBoard(boardId, updates) {
+//   const data = await httpService.put(`boards/${boardId}`, updates);
+//   return data.board;
+// }
+
+function getEmptyCard() {
+  return {
+    _id: crypto.randomUUID(),
+    title: "",
+    description: "",
+    labelIds: [],
+    createdAt: null,
+    archivedAt: null,
+  };
+}
+
+async function addCard(boardId, listId, card) {
+  const cardData = {
+    ...card,
+    listId,
+    boardId,
+  };
+  return await httpService.post("cards", cardData);;
+}
+
+// async function editCard(boardId, card, listId) {
+//   const data = await httpService.put(`cards/${card._id}`, card);
+//   return { listId, card: data.card };
+// }
+
+// async function deleteCard(boardId, cardId, listId) {
+//   await httpService.delete(`cards/${cardId}`);
+//   return { cardId };
+// }
+
+// async function copyCard(copyData, card) {
+//   const {
+//     destinationBoardId,
+//     destinationListId,
+//     keepLabels,
+//     keepMembers,
+//     position,
+//     title,
+//   } = copyData;
+
+//   const clonedCard = {
+//     title,
+//     description: card.description,
+//     listId: destinationListId,
+//     boardId: destinationBoardId,
+//     assignedTo: keepMembers ? card.assignedTo : [],
+//     labelIds: keepLabels ? card.labelIds : [],
+//     position,
+//   };
+
+//   const data = await httpService.post("cards", clonedCard);
+//   return data.card;
+// }
+
+// async function moveCard(moveData, card) {
+//   const { destinationListId, destinationBoardId, position } = moveData;
+
+//   const payload = {
+//     listId: destinationListId,
+//     boardId: destinationBoardId,
+//     targetIndex: position,
+//   };
+
+//   const data = await httpService.put(`cards/${card._id}/move`, payload);
+//   return data.card;
+// }
+
+// function getEmptyList() {
+//   return {
+//     _id: crypto.randomUUID(),
+//     title: "",
+//     cards: [],
+//     archivedAt: null,
+//     position: null,
+//   };
+// }
+
+// async function createList(boardId, listData) {
+//   const payload = {
+//     ...listData,
+//     boardId,
+//   };
+//   const data = await httpService.post("lists", payload);
+//   return data.list;
+// }
+
+// async function moveList(listId, targetBoardId, targetIndex) {
+//   const payload = {
+//     boardId: targetBoardId,
+//     targetIndex,
+//   };
+//   const data = await httpService.put(`lists/${listId}/move`, payload);
+//   return data.list;
+// }
+
+// async function copyList(boardId, listId, newName) {
+//   const list = await httpService.get(`lists/${listId}`);
+//   const originalList = list.list;
+
+//   const clonedList = {
+//     title: newName,
+//     boardId,
+//   };
+
+//   const createdList = await httpService.post("lists", clonedList);
+//   const newList = createdList.list;
+
+//   for (const card of originalList.cards || []) {
+//     await httpService.post("cards", {
+//       title: card.title,
+//       description: card.description,
+//       listId: newList._id,
+//       boardId,
+//       labelIds: card.labelIds,
+//       assignedTo: card.assignedTo,
+//     });
+//   }
+
+//   return newList;
+// }
+
+// async function archiveList(boardId, listId) {
+//   const data = await httpService.put(`lists/${listId}/archive`);
+//   return data.list;
+// }
+
+// async function unarchiveList(boardId, listId) {
+//   const payload = { archivedAt: null };
+//   const data = await httpService.put(`lists/${listId}`, payload);
+//   return data.list;
+// }
+
+// async function moveAllCards(boardId, sourceListId, targetListId, options = {}) {
+//   const sourceList = await httpService.get(`lists/${sourceListId}`);
+//   const cards = sourceList.list.cards || [];
+
+//   let targetId = targetListId;
+//   if (!targetId) {
+//     const newList = await createList(boardId, {
+//       title: options.newListTitle || "New List",
+//     });
+//     targetId = newList._id;
+//   }
+
+//   for (const card of cards) {
+//     await httpService.put(`cards/${card._id}/move`, {
+//       listId: targetId,
+//       boardId,
+//       targetIndex: 0,
+//     });
+//   }
+
+//   return { sourceListId, targetListId: targetId };
+// }
+
+// async function archiveAllCardsInList(boardId, listId) {
+//   const sourceList = await httpService.get(`lists/${listId}`);
+//   const cards = sourceList.list.cards || [];
+
+//   for (const card of cards) {
+//     if (!card.archivedAt) {
+//       await httpService.put(`cards/${card._id}`, {
+//         archivedAt: Date.now(),
+//       });
+//     }
+//   }
+
+//   return { listId };
+// }
 
 async function updateCardLabels(_boardId, _listId, cardId, updatedCardLabels) {
   const payload = {
     labelIds: updatedCardLabels,
   };
-  try {
-    const data = await httpService.put(`cards/${cardId}`, payload);
-    console.log("data card", data);
-    return updatedCardLabels;
-  } catch (error) {
-    console.error("Cannot update card labels:", error);
-    throw error;
-  }
+  const data = await httpService.put(`cards/${cardId}`, payload);
+  console.log("data card", data);
+  return updatedCardLabels;
 }
+
+// async function createLabel(boardId, label) {
+//   const data = await httpService.post(`boards/${boardId}/labels`, label);
+//   return data.labels;
+// }
+
+// async function editLabel(boardId, label) {
+//   const data = await httpService.put(
+//     `boards/${boardId}/labels/${label._id}`,
+//     label
+//   );
+//   return data.labels;
+// }
+
+// async function deleteLabel(boardId, labelId) {
+//   const data = await httpService.delete(`boards/${boardId}/labels/${labelId}`);
+//   return data.labels;
+// }
+
+// async function getBoardPreviews() {
+//   const data = await httpService.get("boards");
+//   return data.boards.map(board => ({
+//     _id: board._id,
+//     title: board.title,
+//   }));
+// }
+
+// async function getBoardListPreviews(boardId) {
+//   const data = await httpService.get("lists", { boardId });
+//   return data.lists.map(list => ({
+//     _id: list._id,
+//     title: list.title,
+//     cardCount: list.cards?.length || 0,
+//   }));
+// }

--- a/frontend/src/services/board/board-service-remote.js
+++ b/frontend/src/services/board/board-service-remote.js
@@ -26,7 +26,7 @@ export const boardService = {
   editLabel,
   deleteLabel,
   getBoardPreviews,
-  // getBoardListPreviews,
+  getBoardListPreviews,
 };
 
 async function query() {
@@ -268,11 +268,11 @@ async function getBoardPreviews() {
   }));
 }
 
-// async function getBoardListPreviews(boardId) {
-//   const data = await httpService.get("lists", { boardId });
-//   return data.lists.map(list => ({
-//     _id: list._id,
-//     title: list.title,
-//     cardCount: list.cards?.length || 0,
-//   }));
-// }
+async function getBoardListPreviews(boardId) {
+  const data = await httpService.get("lists", { boardId });
+  return data.lists.map(list => ({
+    _id: list._id,
+    title: list.title,
+    cardCount: list.cards?.length || 0,
+  }));
+}

--- a/frontend/src/services/board/board-service-remote.js
+++ b/frontend/src/services/board/board-service-remote.js
@@ -144,7 +144,7 @@ async function createList(boardId, listData) {
   };
   const data = await httpService.post("lists", payload);
   if (!data.list.cards) data.list.cards = [];
-  return data;
+  return data.list;
 }
 
 async function moveList(listId, targetBoardId, targetIndex) {

--- a/frontend/src/services/board/board-service-remote.js
+++ b/frontend/src/services/board/board-service-remote.js
@@ -16,7 +16,7 @@ export const boardService = {
   getEmptyList,
   createList,
   moveList,
-  // copyList,
+  copyList,
   // archiveList,
   // unarchiveList,
   // moveAllCards,
@@ -156,31 +156,19 @@ async function moveList(listId, targetBoardId, targetIndex) {
   return data.list;
 }
 
-// async function copyList(boardId, listId, newName) {
-//   const list = await httpService.get(`lists/${listId}`);
-//   const originalList = list.list;
+async function copyList(listId, copyOptions = {}) {
+  const defaultOptions = {
+    copyCards: true,
+    targetBoardId: null,
+    targetIndex: null,
+    title: null,
+  };
 
-//   const clonedList = {
-//     title: newName,
-//     boardId,
-//   };
+  const mergedOptions = { ...defaultOptions, ...copyOptions };
 
-//   const createdList = await httpService.post("lists", clonedList);
-//   const newList = createdList.list;
-
-//   for (const card of originalList.cards || []) {
-//     await httpService.post("cards", {
-//       title: card.title,
-//       description: card.description,
-//       listId: newList._id,
-//       boardId,
-//       labelIds: card.labelIds,
-//       assignedTo: card.assignedTo,
-//     });
-//   }
-
-//   return newList;
-// }
+  const data = await httpService.post(`lists/${listId}/copy`, mergedOptions);
+  return data.list;
+}
 
 // async function archiveList(boardId, listId) {
 //   const data = await httpService.put(`lists/${listId}/archive`);

--- a/frontend/src/services/board/board-service-remote.js
+++ b/frontend/src/services/board/board-service-remote.js
@@ -10,7 +10,7 @@ export const boardService = {
   // getEmptyCard,
   addCard,
   editCard,
-  // deleteCard,
+  deleteCard,
   // copyCard,
   // moveCard,
   // getEmptyList,
@@ -87,10 +87,10 @@ async function editCard(_boardId, card, _listId) {
   return await httpService.put(`cards/${card._id}`, card);
 }
 
-// async function deleteCard(boardId, cardId, listId) {
-//   await httpService.delete(`cards/${cardId}`);
-//   return { cardId };
-// }
+async function deleteCard(boardId, cardId, listId) {
+  await httpService.delete(`cards/${cardId}`);
+  return { cardId };
+}
 
 // async function copyCard(copyData, card) {
 //   const {

--- a/frontend/src/services/board/board-service-remote.js
+++ b/frontend/src/services/board/board-service-remote.js
@@ -23,7 +23,7 @@ export const boardService = {
   // archiveAllCardsInList,
   updateCardLabels,
   createLabel,
-  // editLabel,
+  editLabel,
   // deleteLabel,
   // getBoardPreviews,
   // getBoardListPreviews,
@@ -247,13 +247,13 @@ async function createLabel(boardId, label) {
   return data.label;
 }
 
-// async function editLabel(boardId, label) {
-//   const data = await httpService.put(
-//     `boards/${boardId}/labels/${label._id}`,
-//     label
-//   );
-//   return data.labels;
-// }
+async function editLabel(boardId, label) {
+  const data = await httpService.put(
+    `boards/${boardId}/labels/${label._id}`,
+    label
+  );
+  return data.label;
+}
 
 // async function deleteLabel(boardId, labelId) {
 //   const data = await httpService.delete(`boards/${boardId}/labels/${labelId}`);

--- a/frontend/src/services/board/board-service-remote.js
+++ b/frontend/src/services/board/board-service-remote.js
@@ -82,7 +82,8 @@ async function addCard(boardId, listId, card) {
 }
 
 async function editCard(_boardId, card, _listId) {
-  return await httpService.put(`cards/${card._id}`, card);
+  const data = await httpService.put(`cards/${card._id}`, card);
+  return data.card;
 }
 
 async function deleteCard(boardId, cardId, listId) {

--- a/frontend/src/services/board/board-service-remote.js
+++ b/frontend/src/services/board/board-service-remote.js
@@ -13,8 +13,8 @@ export const boardService = {
   deleteCard,
   // copyCard,
   // moveCard,
-  // getEmptyList,
-  // createList,
+  getEmptyList,
+  createList,
   // moveList,
   // copyList,
   // archiveList,
@@ -129,24 +129,25 @@ async function deleteCard(boardId, cardId, listId) {
 //   return data.card;
 // }
 
-// function getEmptyList() {
-//   return {
-//     _id: crypto.randomUUID(),
-//     title: "",
-//     cards: [],
-//     archivedAt: null,
-//     position: null,
-//   };
-// }
+function getEmptyList() {
+  return {
+    _id: crypto.randomUUID(),
+    title: "",
+    cards: [],
+    archivedAt: null,
+    position: null,
+  };
+}
 
-// async function createList(boardId, listData) {
-//   const payload = {
-//     ...listData,
-//     boardId,
-//   };
-//   const data = await httpService.post("lists", payload);
-//   return data.list;
-// }
+async function createList(boardId, listData) {
+  const payload = {
+    ...listData,
+    boardId,
+  };
+  const data = await httpService.post("lists", payload);
+  if (!data.list.cards) data.list.cards = [];
+  return data;
+}
 
 // async function moveList(listId, targetBoardId, targetIndex) {
 //   const payload = {

--- a/frontend/src/services/board/board-service-remote.js
+++ b/frontend/src/services/board/board-service-remote.js
@@ -24,7 +24,7 @@ export const boardService = {
   updateCardLabels,
   createLabel,
   editLabel,
-  // deleteLabel,
+  deleteLabel,
   // getBoardPreviews,
   // getBoardListPreviews,
 };
@@ -255,10 +255,10 @@ async function editLabel(boardId, label) {
   return data.label;
 }
 
-// async function deleteLabel(boardId, labelId) {
-//   const data = await httpService.delete(`boards/${boardId}/labels/${labelId}`);
-//   return data.labels;
-// }
+async function deleteLabel(boardId, labelId) {
+  await httpService.delete(`boards/${boardId}/labels/${labelId}`);
+  return labelId;
+}
 
 // async function getBoardPreviews() {
 //   const data = await httpService.get("boards");

--- a/frontend/src/services/board/board-service-remote.js
+++ b/frontend/src/services/board/board-service-remote.js
@@ -12,7 +12,7 @@ export const boardService = {
   editCard,
   deleteCard,
   copyCard,
-  // moveCard,
+  moveCard,
   getEmptyList,
   createList,
   // moveList,
@@ -115,18 +115,18 @@ async function copyCard(copyData, card) {
   return data.card;
 }
 
-// async function moveCard(moveData, card) {
-//   const { destinationListId, destinationBoardId, position } = moveData;
+async function moveCard(moveData, card) {
+  const { destinationListId, destinationBoardId, position } = moveData;
 
-//   const payload = {
-//     listId: destinationListId,
-//     boardId: destinationBoardId,
-//     targetIndex: position,
-//   };
+  const payload = {
+    listId: destinationListId,
+    boardId: destinationBoardId,
+    targetIndex: position,
+  };
 
-//   const data = await httpService.put(`cards/${card._id}/move`, payload);
-//   return data.card;
-// }
+  const data = await httpService.put(`cards/${card._id}/move`, payload);
+  return data.card;
+}
 
 function getEmptyList() {
   return {

--- a/frontend/src/services/board/board-service-remote.js
+++ b/frontend/src/services/board/board-service-remote.js
@@ -77,7 +77,8 @@ async function addCard(boardId, listId, card) {
     listId,
     boardId,
   };
-  return await httpService.post("cards", cardData);
+  const data = await httpService.post("cards", cardData);
+  return data.card;
 }
 
 async function editCard(_boardId, card, _listId) {

--- a/frontend/src/services/board/board-service-remote.js
+++ b/frontend/src/services/board/board-service-remote.js
@@ -25,7 +25,7 @@ export const boardService = {
   createLabel,
   editLabel,
   deleteLabel,
-  // getBoardPreviews,
+  getBoardPreviews,
   // getBoardListPreviews,
 };
 
@@ -260,13 +260,13 @@ async function deleteLabel(boardId, labelId) {
   return labelId;
 }
 
-// async function getBoardPreviews() {
-//   const data = await httpService.get("boards");
-//   return data.boards.map(board => ({
-//     _id: board._id,
-//     title: board.title,
-//   }));
-// }
+async function getBoardPreviews() {
+  const data = await httpService.get("boards");
+  return data.boards.map(board => ({
+    _id: board._id,
+    title: board.title,
+  }));
+}
 
 // async function getBoardListPreviews(boardId) {
 //   const data = await httpService.get("lists", { boardId });

--- a/frontend/src/services/board/board-service-remote.js
+++ b/frontend/src/services/board/board-service-remote.js
@@ -9,7 +9,7 @@ export const boardService = {
   // updateBoard,
   // getEmptyCard,
   addCard,
-  // editCard,
+  editCard,
   // deleteCard,
   // copyCard,
   // moveCard,
@@ -80,13 +80,12 @@ async function addCard(boardId, listId, card) {
     listId,
     boardId,
   };
-  return await httpService.post("cards", cardData);;
+  return await httpService.post("cards", cardData);
 }
 
-// async function editCard(boardId, card, listId) {
-//   const data = await httpService.put(`cards/${card._id}`, card);
-//   return { listId, card: data.card };
-// }
+async function editCard(_boardId, card, _listId) {
+  return await httpService.put(`cards/${card._id}`, card);
+}
 
 // async function deleteCard(boardId, cardId, listId) {
 //   await httpService.delete(`cards/${cardId}`);

--- a/frontend/src/services/board/board-service-remote.js
+++ b/frontend/src/services/board/board-service-remote.js
@@ -15,7 +15,7 @@ export const boardService = {
   moveCard,
   getEmptyList,
   createList,
-  // moveList,
+  moveList,
   // copyList,
   // archiveList,
   // unarchiveList,
@@ -148,14 +148,14 @@ async function createList(boardId, listData) {
   return data;
 }
 
-// async function moveList(listId, targetBoardId, targetIndex) {
-//   const payload = {
-//     boardId: targetBoardId,
-//     targetIndex,
-//   };
-//   const data = await httpService.put(`lists/${listId}/move`, payload);
-//   return data.list;
-// }
+async function moveList(listId, targetBoardId, targetIndex) {
+  const payload = {
+    boardId: targetBoardId,
+    targetIndex,
+  };
+  const data = await httpService.put(`lists/${listId}/move`, payload);
+  return data.list;
+}
 
 // async function copyList(boardId, listId, newName) {
 //   const list = await httpService.get(`lists/${listId}`);

--- a/frontend/src/store/actions/auth-actions.js
+++ b/frontend/src/store/actions/auth-actions.js
@@ -23,7 +23,6 @@ export async function login(credentials) {
   try {
     store.dispatch({ type: LOGIN.REQUEST, key: LOGIN.KEY });
     const user = await authService.login(credentials);
-    authService.setCurrentUserInSession(user);
     store.dispatch({ type: LOGIN.SUCCESS, payload: user });
     return user;
   } catch (error) {

--- a/frontend/src/store/actions/board-actions.js
+++ b/frontend/src/store/actions/board-actions.js
@@ -103,17 +103,11 @@ export async function deleteBoard(boardId) {
   }
 }
 
-export async function createList(boardId, listData) {
-  try {
-    store.dispatch({ type: ADD_LIST.REQUEST });
-    const newList = await boardService.createList(boardId, listData);
-    store.dispatch({ type: ADD_LIST.SUCCESS, payload: newList });
-    return newList;
-  } catch (error) {
-    store.dispatch({ type: ADD_LIST.FAILURE, payload: error.message });
-    throw error;
-  }
-}
+export const createList = createAsyncAction(
+  ADD_LIST,
+  boardService.createList,
+  store
+);
 
 export const moveList = createAsyncAction(
   MOVE_LIST,

--- a/frontend/src/store/actions/board-actions.js
+++ b/frontend/src/store/actions/board-actions.js
@@ -280,10 +280,6 @@ export function deleteBoardAction(boardId) {
   return { type: DELETE_BOARD, payload: boardId };
 }
 
-export function addCardAction(card, listId) {
-  return { type: ADD_CARD, payload: { card, listId } };
-}
-
 export function editCardAction(card, listId) {
   return { type: EDIT_CARD, payload: { card, listId } };
 }

--- a/frontend/src/store/actions/board-actions.js
+++ b/frontend/src/store/actions/board-actions.js
@@ -186,16 +186,11 @@ export const moveCard = createAsyncAction(
   store
 );
 
-export async function createLabel(boardId, label) {
-  try {
-    store.dispatch({ type: CREATE_LABEL.REQUEST });
-    await boardService.createLabel(boardId, label);
-    store.dispatch({ type: CREATE_LABEL.SUCCESS, payload: label });
-  } catch (error) {
-    store.dispatch({ type: CREATE_LABEL.FAILURE, payload: error.message });
-    throw error;
-  }
-}
+export const createLabel = createAsyncAction(
+  CREATE_LABEL,
+  boardService.createLabel,
+  store
+);
 
 export async function editLabel(boardId, label) {
   try {

--- a/frontend/src/store/actions/board-actions.js
+++ b/frontend/src/store/actions/board-actions.js
@@ -192,16 +192,11 @@ export const createLabel = createAsyncAction(
   store
 );
 
-export async function editLabel(boardId, label) {
-  try {
-    store.dispatch({ type: EDIT_LABEL.REQUEST });
-    await boardService.editLabel(boardId, label);
-    store.dispatch({ type: EDIT_LABEL.SUCCESS, payload: label });
-  } catch (error) {
-    store.dispatch({ type: EDIT_LABEL.FAILURE, payload: error.message });
-    throw error;
-  }
-}
+export const editLabel = createAsyncAction(
+  EDIT_LABEL,
+  boardService.editLabel,
+  store
+);
 
 export async function deleteLabel(boardId, labelId) {
   try {

--- a/frontend/src/store/actions/board-actions.js
+++ b/frontend/src/store/actions/board-actions.js
@@ -174,17 +174,11 @@ export const editCard = createAsyncAction(
   store
 );
 
-export async function deleteCard(boardId, cardId, listId) {
-  try {
-    await boardService.deleteCard(boardId, cardId, listId);
-    store.dispatch(deleteCardAction(cardId, listId));
-  } catch (error) {
-    store.dispatch(
-      setError("deleteCard", `Error deleting card: ${error.message}`)
-    );
-    throw error;
-  }
-}
+export const deleteCard = createAsyncAction(
+  DELETE_CARD,
+  boardService.deleteCard,
+  store
+);
 
 export const copyCard = createAsyncAction(
   COPY_CARD,

--- a/frontend/src/store/actions/board-actions.js
+++ b/frontend/src/store/actions/board-actions.js
@@ -198,16 +198,11 @@ export const editLabel = createAsyncAction(
   store
 );
 
-export async function deleteLabel(boardId, labelId) {
-  try {
-    store.dispatch({ type: DELETE_LABEL.REQUEST });
-    await boardService.deleteLabel(boardId, labelId);
-    store.dispatch({ type: DELETE_LABEL.SUCCESS, payload: labelId });
-  } catch (error) {
-    store.dispatch({ type: DELETE_LABEL.FAILURE, payload: error.message });
-    throw error;
-  }
-}
+export const deleteLabel = createAsyncAction(
+  DELETE_LABEL,
+  boardService.deleteLabel,
+  store
+);
 
 export async function updateCardLabels(
   boardId,

--- a/frontend/src/store/reducers/board-reducer.js
+++ b/frontend/src/store/reducers/board-reducer.js
@@ -144,11 +144,11 @@ const handlers = {
     board: {
       ...state.board,
       lists: state.board.lists.map(list =>
-        list._id !== action.payload.card.listId
+        list._id !== action.payload.listId
           ? list
           : {
               ...list,
-              cards: sortByPosition([...list.cards, action.payload.card]),
+              cards: sortByPosition([...list.cards, action.payload]),
             }
       ),
     },

--- a/frontend/src/store/reducers/board-reducer.js
+++ b/frontend/src/store/reducers/board-reducer.js
@@ -200,7 +200,17 @@ const handlers = {
     loading: { ...state.loading, [MOVE_CARD.KEY]: false },
     board: {
       ...state.board,
-      lists: action.payload,
+      lists: state.board.lists.map(list =>
+        list._id === action.payload.listId
+          ? {
+              ...list,
+              cards: sortByPosition([...list.cards, action.payload]),
+            }
+          : {
+              ...list,
+              cards: list.cards.filter(card => card._id !== action.payload._id),
+            }
+      ),
     },
   }),
   ...createAsyncHandlers(CREATE_LABEL, CREATE_LABEL.KEY),

--- a/frontend/src/store/reducers/board-reducer.js
+++ b/frontend/src/store/reducers/board-reducer.js
@@ -160,12 +160,12 @@ const handlers = {
     board: {
       ...state.board,
       lists: state.board.lists.map(list =>
-        list._id === action.payload.card.listId
+        list._id === action.payload.listId
           ? {
               ...list,
               cards: list.cards.map(card =>
-                card._id === action.payload.card._id
-                  ? { ...card, ...action.payload.card }
+                card._id === action.payload._id
+                  ? { ...card, ...action.payload }
                   : card
               ),
             }

--- a/frontend/src/store/reducers/board-reducer.js
+++ b/frontend/src/store/reducers/board-reducer.js
@@ -185,7 +185,12 @@ const handlers = {
     board: {
       ...state.board,
       lists: state.board.lists.map(list =>
-        list._id === action.payload._id ? action.payload : list
+        list._id === action.payload.listId
+          ? {
+              ...list,
+              cards: sortByPosition([...list.cards, action.payload]),
+            }
+          : list
       ),
     },
   }),

--- a/frontend/src/store/reducers/board-reducer.js
+++ b/frontend/src/store/reducers/board-reducer.js
@@ -133,7 +133,12 @@ const handlers = {
     board: {
       ...state.board,
       lists: state.board.lists.map(list =>
-        list._id === action.payload._id ? action.payload : list
+        list._id !== action.payload.card.listId
+          ? list
+          : {
+              ...list,
+              cards: sortByPosition([...list.cards, action.payload.card]),
+            }
       ),
     },
   }),

--- a/frontend/src/store/reducers/board-reducer.js
+++ b/frontend/src/store/reducers/board-reducer.js
@@ -220,17 +220,23 @@ const handlers = {
     loading: { ...state.loading, [MOVE_CARD.KEY]: false },
     board: {
       ...state.board,
-      lists: state.board.lists.map(list =>
-        list._id === action.payload.listId
-          ? {
-              ...list,
-              cards: sortByPosition([...list.cards, action.payload]),
-            }
-          : {
-              ...list,
-              cards: list.cards.filter(card => card._id !== action.payload._id),
-            }
-      ),
+      lists: state.board.lists.map(list => {
+        const filteredCards = list.cards.filter(
+          card => card._id !== action.payload._id
+        );
+
+        if (list._id === action.payload.listId) {
+          return {
+            ...list,
+            cards: sortByPosition([...filteredCards, action.payload]),
+          };
+        }
+
+        return {
+          ...list,
+          cards: filteredCards,
+        };
+      }),
     },
   }),
   ...createAsyncHandlers(CREATE_LABEL, CREATE_LABEL.KEY),

--- a/frontend/src/store/reducers/board-reducer.js
+++ b/frontend/src/store/reducers/board-reducer.js
@@ -46,7 +46,7 @@ const handlers = {
     loading: { ...state.loading, [ADD_LIST.KEY]: false },
     board: {
       ...state.board,
-      lists: [...state.board.lists, action.payload],
+      lists: sortByPosition([...state.board.lists, action.payload.list]),
     },
   }),
   ...createAsyncHandlers(MOVE_ALL_CARDS, MOVE_ALL_CARDS.KEY),

--- a/frontend/src/store/reducers/board-reducer.js
+++ b/frontend/src/store/reducers/board-reducer.js
@@ -129,14 +129,23 @@ const handlers = {
     };
   },
   ...createAsyncHandlers(COPY_LIST, COPY_LIST.KEY),
-  [COPY_LIST.SUCCESS]: (state, action) => ({
-    ...state,
-    loading: { ...state.loading, [COPY_LIST.KEY]: false },
-    board: {
-      ...state.board,
-      lists: action.payload,
-    },
-  }),
+  [COPY_LIST.SUCCESS]: (state, action) => {
+    let newLists;
+    if (state.board._id === action.payload.boardId) {
+      newLists = [...state.board.lists, action.payload];
+      newLists = sortByPosition(newLists);
+      return {
+        ...state,
+        loading: { ...state.loading, [COPY_LIST.KEY]: false },
+        board: {
+          ...state.board,
+          lists: newLists,
+        },
+      };
+    } else {
+      return state;
+    }
+  },
   ...createAsyncHandlers(ADD_CARD, ADD_CARD.KEY),
   [ADD_CARD.SUCCESS]: (state, action) => ({
     ...state,

--- a/frontend/src/store/reducers/board-reducer.js
+++ b/frontend/src/store/reducers/board-reducer.js
@@ -109,11 +109,22 @@ const handlers = {
   }),
   ...createAsyncHandlers(MOVE_LIST, MOVE_LIST.KEY),
   [MOVE_LIST.SUCCESS]: (state, action) => {
+    let newLists;
+    if (state.board._id !== action.payload.boardId) {
+      newLists = state.board.lists.filter(
+        list => list._id !== action.payload._id
+      );
+    } else {
+      newLists = state.board.lists.map(list =>
+        list._id === action.payload._id ? { ...list, ...action.payload } : list
+      );
+      newLists = sortByPosition(newLists);
+    }
     return {
       ...state,
       board: {
         ...state.board,
-        lists: action.payload,
+        lists: newLists,
       },
     };
   },

--- a/frontend/src/store/reducers/board-reducer.js
+++ b/frontend/src/store/reducers/board-reducer.js
@@ -149,12 +149,12 @@ const handlers = {
     board: {
       ...state.board,
       lists: state.board.lists.map(list =>
-        list._id === action.payload.listId
+        list._id === action.payload.card.listId
           ? {
               ...list,
               cards: list.cards.map(card =>
                 card._id === action.payload.card._id
-                  ? action.payload.card
+                  ? { ...card, ...action.payload.card }
                   : card
               ),
             }

--- a/frontend/src/store/reducers/board-reducer.js
+++ b/frontend/src/store/reducers/board-reducer.js
@@ -46,7 +46,7 @@ const handlers = {
     loading: { ...state.loading, [ADD_LIST.KEY]: false },
     board: {
       ...state.board,
-      lists: sortByPosition([...state.board.lists, action.payload.list]),
+      lists: sortByPosition([...state.board.lists, action.payload]),
     },
   }),
   ...createAsyncHandlers(MOVE_ALL_CARDS, MOVE_ALL_CARDS.KEY),


### PR DESCRIPTION
## 🎯 Description
This PR connects the Trello clone frontend with the backend server, replacing local storage with REST API calls for real data persistence and multi-user functionality.

## 🔧 Changes
- Connected both auth and board services (remote versions) with the backend.

## 📝 Notes
- Made some fixes to bugs i found in the backend/frontend along the way.
- Some function are still commented out and wont work in at all as they aren't implemented in the server yet.
- Many of the implementations are breaking changes  as some function signatures changed and using the local service will not be possible anymore.
- Some state changes in the frontend were made to work with different responses from the server from what we worked with locally. for example when we move a list, we don't want to query all the board lists all over, and instead we only return the moved list, with which hte frontend will know whether to filter it out or to resort the lists array (no need to send data the frontend already has, and this also is consistent with REST way of doing things).
- The following functoin currently wont work, as most of them are not yet implemented in the backend. Will work on them ASAP.
