### PR TITLE
 bugfix/CATC_85-fix-multiple-renders-on-initial-load-of-board-details

### DIFF
--- a/frontend/src/pages/BoardDetails.jsx
+++ b/frontend/src/pages/BoardDetails.jsx
@@ -25,7 +25,6 @@ import {
   copyList,
   createList,
   loadBoard,
-  loadBoards,
   moveAllCards,
   moveCard,
   moveList,
@@ -37,7 +36,6 @@ export function BoardDetails() {
   const params = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
   const board = useSelector(state => state.boards.board);
-  const boards = useSelector(state => state.boards.boards);
   const [labelsIsOpen, setLabelsIsOpen] = useState(false);
   const boardCanvasRef = useRef(null);
   const scrollBoardToEnd = useScrollTo(boardCanvasRef);
@@ -62,6 +60,14 @@ export function BoardDetails() {
     const filterBy = parseFiltersFromSearchParams(searchParams);
     updateFilters(filterBy);
   }, []);
+
+  useEffect(() => {
+    // Only load board when we have both boardId and filters (after URL parsing)
+    console.log("🚀 ~ BoardDetails ~ filters:", filters);
+    if (params.boardId && filters !== undefined) {
+      loadBoard(params.boardId, filters);
+    }
+  }, [params.boardId, filters]);
 
   useEffect(() => {
     const filterBy = serializeFiltersToSearchParams(filters);

--- a/frontend/src/pages/BoardDetails.jsx
+++ b/frontend/src/pages/BoardDetails.jsx
@@ -42,6 +42,7 @@ export function BoardDetails() {
   useDragToScroll(boardCanvasRef, { sensitivity: 1, enabled: !!board }); //drag to scroll the board experimentall
   const { filters, updateFilters } = useCardFilters();
   const [lists, setLists] = useState(board?.lists || []);
+  const isFromUrlUpdate = useRef(false);
 
   useEffect(() => {
     if (board) {
@@ -50,21 +51,31 @@ export function BoardDetails() {
   }, [board]);
 
   useEffect(() => {
-    loadBoard(params.boardId, filters);
-    if (!boards || boards.length === 0) {
-      loadBoards();
+    if (params.boardId) {
+      const urlFilters = parseFiltersFromSearchParams(searchParams);
+      isFromUrlUpdate.current = true;
+      updateFilters(urlFilters);
+    }
+  }, [params.boardId, updateFilters]);
+
+  useEffect(() => {
+    if (params.boardId && filters && !isFromUrlUpdate.current) {
+      loadBoard(params.boardId, filters);
     }
   }, [params.boardId, filters]);
 
   useEffect(() => {
-    const filterBy = parseFiltersFromSearchParams(searchParams);
-    updateFilters(filterBy);
-  }, []);
+    if (!isFromUrlUpdate.current) {
+      const filterBy = serializeFiltersToSearchParams(filters);
+      setSearchParams(filterBy);
+    }
+  }, [filters, setSearchParams]);
 
   useEffect(() => {
-    const filterBy = serializeFiltersToSearchParams(filters);
-    setSearchParams(filterBy);
-  }, [filters, setSearchParams]);
+    if (isFromUrlUpdate.current) {
+      isFromUrlUpdate.current = false;
+    }
+  }, [filters]);
 
   async function onCopyList(listId, copyOptions) {
     try {

--- a/frontend/src/pages/BoardDetails.jsx
+++ b/frontend/src/pages/BoardDetails.jsx
@@ -62,14 +62,6 @@ export function BoardDetails() {
   }, []);
 
   useEffect(() => {
-    // Only load board when we have both boardId and filters (after URL parsing)
-    console.log("🚀 ~ BoardDetails ~ filters:", filters);
-    if (params.boardId && filters !== undefined) {
-      loadBoard(params.boardId, filters);
-    }
-  }, [params.boardId, filters]);
-
-  useEffect(() => {
     const filterBy = serializeFiltersToSearchParams(filters);
     setSearchParams(filterBy);
   }, [filters, setSearchParams]);

--- a/frontend/src/store/actions/board-actions.js
+++ b/frontend/src/store/actions/board-actions.js
@@ -46,19 +46,11 @@ export async function loadBoards() {
   }
 }
 
-export async function loadBoard(boardId, filterBy = {}) {
-  try {
-    store.dispatch(setLoading("loadBoard", true));
-    const board = await boardService.getFullById(boardId, filterBy);
-    store.dispatch(setBoard(board));
-  } catch (error) {
-    store.dispatch(
-      setError("loadBoard", `Error loading board: ${error.message}`)
-    );
-  } finally {
-    store.dispatch(setLoading("loadBoard", false));
-  }
-}
+export const loadBoard = createAsyncAction(
+  SET_BOARD,
+  boardService.getFullById,
+  store
+);
 
 export const createBoard = createAsyncAction(
   ADD_BOARD,

--- a/frontend/src/store/reducers/board-reducer.js
+++ b/frontend/src/store/reducers/board-reducer.js
@@ -3,7 +3,7 @@ import { createAsyncActionTypes, createAsyncHandlers } from "../utils";
 import { sortByPosition } from "../../services/board/fractional-index-service";
 
 export const SET_BOARDS = "SET_BOARDS";
-export const SET_BOARD = "SET_BOARD";
+export const SET_BOARD = createAsyncActionTypes("SET_BOARD");
 export const DELETE_BOARD = "DELETE_BOARD";
 export const ADD_BOARD = createAsyncActionTypes("ADD_BOARD");
 export const UPDATE_BOARD = createAsyncActionTypes("UPDATE_BOARD");
@@ -93,7 +93,8 @@ const handlers = {
     ...state,
     boards: action.payload,
   }),
-  [SET_BOARD]: (state, action) => ({
+  ...createAsyncHandlers(SET_BOARD, SET_BOARD.KEY),
+  [SET_BOARD.SUCCESS]: (state, action) => ({
     ...state,
     board: action.payload,
   }),


### PR DESCRIPTION
## 🎯 Description

Fixes double board loading on initial page load by implementing source-aware filter management to eliminate race conditions between URL parsing and UI filter state updates.

## 🔧 Changes

- **🏗️ Filter Source Tracking**: Added `isFromUrlUpdate` ref to differentiate URL vs UI filter changes
- **⚡ Eliminated Double Loading**: Skip board reloads when filters update from URL parsing  
- **🔄 Split Concerns**: Separated URL parsing and UI filter logic into distinct useEffects
- **🎯 Store Helpers**: Refactored `loadBoard` to use store helpers for consistency
- **🧹 Cleanup**: Removed unnecessary imports and board loading calls

## 📝 Notes

- Maintains full UI filter functionality while eliminating redundant API calls
- URL refresh and direct paste scenarios work correctly
- Backward compatible with existing filter functionality
- Uses tracking flag to prevent race conditions

## 🖥️ Demo

<details>
  <summary>Watch Demo Video</summary>

  <p align="center">
   

https://github.com/user-attachments/assets/b22a3948-768a-4560-90c7-94a5aad03e14


  </p>

</details>