### PR TITLE
bugfix/CATC_148-fix-move-list-bad-positioning

### DIFF
--- a/backend/src/services/list-service.js
+++ b/backend/src/services/list-service.js
@@ -43,7 +43,9 @@ export async function moveList(listId, boardId, targetIndex) {
     throw createHttpError(404, "Board not found");
   }
 
-  let lists = await List.find({ boardId }).sort({ position: 1 });
+  let lists = await List.find({ boardId, _id: { $ne: listId } }).sort({
+    position: 1,
+  });
   let newPosition = calculateNewPosition(lists, targetIndex);
 
   return await List.findByIdAndUpdate(


### PR DESCRIPTION
## 🎯 Description

Fixes list positioning bug when moving lists via drag and drop or move-list action.

## 🔧 Changes

- 🐛 __Bug Fix__: Modified `moveList` function to exclude moving list from position calculations

## 📝 Notes

Issue: Moving list from index 0 to index 2 placed it at index 1 instead of 2.

Fix: Filter out moving list during position calculation.

## 🖥️ Demo

<details>
  <summary>Watch Demo Video</summary>

  <p align="center">

https://github.com/user-attachments/assets/9c5a1f58-e00f-4c6e-af9c-3c0b31fd25be


  </p>

</details>
