### PR TITLE
feature/CATC_151-implement-filters-in-the-backend

### DIFF
--- a/backend/src/controllers/board-controller.js
+++ b/backend/src/controllers/board-controller.js
@@ -45,7 +45,30 @@ export async function getBoardById(req, res) {
 }
 
 export async function getFullBoardById(req, res) {
-  const fullBoard = await boardService.getFullBoardById(req.params.id);
+  const { title, labels, members, noMembers, includeNoLabels } = req.query;
+
+  const filterBy = {
+    title,
+    labels: labels
+      ? labels
+          .split(",")
+          .map(id => id.trim())
+          .filter(id => id)
+      : undefined,
+    members: members
+      ? members
+          .split(",")
+          .map(id => id.trim())
+          .filter(id => id)
+      : undefined,
+    noMembers: noMembers === "true" || noMembers === "1",
+    includeNoLabels: includeNoLabels === "true" || includeNoLabels === "1",
+  };
+
+  const fullBoard = await boardService.getFullBoardById(
+    req.params.id,
+    filterBy
+  );
   if (!fullBoard) throw createError(404, "Board not found");
 
   res.json({ board: fullBoard });

--- a/backend/src/services/filter-service.js
+++ b/backend/src/services/filter-service.js
@@ -1,0 +1,97 @@
+import mongoose from "mongoose";
+
+/**
+ * Builds MongoDB query for card filtering based on filter criteria
+ * @param {Object} filterBy - Filter criteria
+ * @returns {Object} MongoDB query object
+ */
+export function buildCardFilterQuery(filterBy = {}) {
+  const { title, labels, members, noMembers, includeNoLabels } = filterBy;
+  const query = {};
+
+  if (title && title.trim()) {
+    query.title = {
+      $regex: title.trim(),
+      $options: "i",
+    };
+  }
+
+  if (labels && labels.length > 0) {
+    if (includeNoLabels) {
+      query.$or = [{ labelIds: { $in: labels } }, { labelIds: { $size: 0 } }];
+    } else {
+      query.labelIds = { $in: labels };
+    }
+  } else if (includeNoLabels) {
+    query.labelIds = { $size: 0 };
+  }
+
+  if (members && members.length > 0) {
+    const memberIds = members.map(memberId => {
+      if (typeof memberId === "string") {
+        try {
+          return new mongoose.Types.ObjectId(memberId);
+        } catch (e) {
+          console.warn("Invalid ObjectId format:", memberId);
+          return memberId;
+        }
+      }
+      return memberId;
+    });
+
+    if (noMembers) {
+      const memberQuery = {
+        $or: [
+          { "assignees.userId": { $in: memberIds } },
+          { assignees: { $size: 0 } },
+        ],
+      };
+
+      if (query.$or) {
+        // If we already have $or from label filtering, combine them
+        query.$and = [{ $or: query.$or }, memberQuery];
+        delete query.$or;
+      } else {
+        Object.assign(query, memberQuery);
+      }
+    } else {
+      query["assignees.userId"] = { $in: memberIds };
+    }
+  } else if (noMembers) {
+    query.assignees = { $size: 0 };
+  }
+
+  console.log("🚀 ~ buildCardFilterQuery ~ query:", query);
+  return query;
+}
+
+/**
+ * Validates filter parameters
+ * @param {Object} filterBy - Filter criteria to validate
+ * @returns {Object} Validated and sanitized filter criteria
+ */
+export function validateFilterParams(filterBy = {}) {
+  const validated = {};
+
+  if (filterBy.title && typeof filterBy.title === "string") {
+    validated.title = filterBy.title.trim();
+  }
+
+  if (filterBy.members) {
+    if (Array.isArray(filterBy.members)) {
+      validated.members = filterBy.members.filter(
+        member => member && typeof member === "string"
+      );
+    } else if (typeof filterBy.members === "string") {
+      validated.members = filterBy.members
+        .split(",")
+        .map(member => member.trim())
+        .filter(member => member);
+    }
+  }
+
+  validated.noMembers = Boolean(filterBy.noMembers);
+  validated.includeNoLabels = Boolean(filterBy.includeNoLabels);
+
+  return validated;
+}

--- a/frontend/src/components/FilterMenu.jsx
+++ b/frontend/src/components/FilterMenu.jsx
@@ -12,13 +12,11 @@ import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import { Popover } from "./Popover";
 import { useCardFilters } from "../hooks/useCardFilters";
-import {
-  CURRENT_USER_ID_PLACEHOLDER,
-  getMembersFilterOptions,
-} from "../services/filter-service";
+import { getMembersFilterOptions } from "../services/filter-service";
 
 export function FilterMenu() {
   const members = useSelector(state => state.boards.board.members);
+  const currentUser = useSelector(state => state.auth.currentUser);
   const [isOpen, setIsOpen] = useState(false);
   const [localTitle, setLocalTitle] = useState("");
   const [anchorEl, setAnchorEl] = useState(null);
@@ -62,19 +60,17 @@ export function FilterMenu() {
     if (checkboxName === "assignedToMe") {
       newMembers = filters.members ? [...filters.members] : [];
       if (checked) {
-        newMembers = [...newMembers, CURRENT_USER_ID_PLACEHOLDER];
+        newMembers = [...newMembers, currentUser._id];
       } else {
-        newMembers = newMembers.filter(
-          id => id !== CURRENT_USER_ID_PLACEHOLDER
-        );
+        newMembers = newMembers.filter(id => id !== currentUser._id);
       }
     } else if (checkboxName === "selectAll") {
       if (checked) {
         newMembers = members
-          .filter(m => m._id !== CURRENT_USER_ID_PLACEHOLDER)
+          .filter(m => m._id !== currentUser._id)
           .map(m => m._id);
-        if (filters.members?.includes(CURRENT_USER_ID_PLACEHOLDER)) {
-          newMembers = [CURRENT_USER_ID_PLACEHOLDER, ...newMembers];
+        if (filters.members?.includes(currentUser._id)) {
+          newMembers = [currentUser._id, ...newMembers];
         }
       } else {
         newMembers = [];
@@ -85,7 +81,7 @@ export function FilterMenu() {
 
   function isSomeMembersSelected() {
     if (!members || members.length === 0) return false;
-    const filtered = members.filter(m => m._id !== CURRENT_USER_ID_PLACEHOLDER);
+    const filtered = members.filter(m => m._id !== currentUser._id);
     const selectedCount = filtered.filter(m =>
       filters.members?.includes(m._id)
     ).length;
@@ -105,8 +101,8 @@ export function FilterMenu() {
 
   function handleMembersAutocompleteChange(_, selected) {
     let newMembers = selected.map(m => m.id);
-    if (filters.members?.includes(CURRENT_USER_ID_PLACEHOLDER)) {
-      newMembers = [CURRENT_USER_ID_PLACEHOLDER, ...newMembers];
+    if (filters.members?.includes(currentUser._id)) {
+      newMembers = [currentUser._id, ...newMembers];
     }
     updateFilter("members", newMembers);
   }
@@ -160,9 +156,7 @@ export function FilterMenu() {
               control={
                 <Checkbox
                   name="assignedToMe"
-                  checked={filters.members?.includes(
-                    CURRENT_USER_ID_PLACEHOLDER
-                  )}
+                  checked={filters.members?.includes(currentUser._id)}
                   onChange={handleMembersChange}
                 />
               }
@@ -178,7 +172,7 @@ export function FilterMenu() {
                   checked={
                     memberOptions.length > 0 &&
                     memberOptions
-                      .filter(m => m.id !== CURRENT_USER_ID_PLACEHOLDER)
+                      .filter(m => m.id !== currentUser._id)
                       .every(m => filters.members?.includes(m.id))
                   }
                   indeterminate={isSomeMembersSelected()}
@@ -198,8 +192,7 @@ export function FilterMenu() {
                 getOptionLabel={option => option.label}
                 value={memberOptions.filter(
                   m =>
-                    filters.members?.includes(m.id) &&
-                    m.id !== CURRENT_USER_ID_PLACEHOLDER
+                    filters.members?.includes(m.id) && m.id !== currentUser._id
                 )}
                 onChange={handleMembersAutocompleteChange}
                 renderOption={renderMemberOption}

--- a/frontend/src/components/FilterMenu.jsx
+++ b/frontend/src/components/FilterMenu.jsx
@@ -28,8 +28,9 @@ export function FilterMenu() {
     hasActiveFilters,
   } = useCardFilters();
   const memberOptions = useMemo(
-    () => getMembersFilterOptions(members),
-    [members]
+    () =>
+      getMembersFilterOptions(members).filter(m => m.id !== currentUser._id),
+    [members, currentUser]
   );
 
   function handleClearFilters() {
@@ -66,26 +67,26 @@ export function FilterMenu() {
       }
     } else if (checkboxName === "selectAll") {
       if (checked) {
-        newMembers = members
-          .filter(m => m._id !== currentUser._id)
-          .map(m => m._id);
+        newMembers = memberOptions.map(m => m.id);
         if (filters.members?.includes(currentUser._id)) {
           newMembers = [currentUser._id, ...newMembers];
         }
       } else {
         newMembers = [];
+        if (filters.members?.includes(currentUser._id)) {
+          newMembers = [currentUser._id];
+        }
       }
     }
     updateFilter("members", newMembers);
   }
 
   function isSomeMembersSelected() {
-    if (!members || members.length === 0) return false;
-    const filtered = members.filter(m => m._id !== currentUser._id);
-    const selectedCount = filtered.filter(m =>
-      filters.members?.includes(m._id)
+    if (!memberOptions || memberOptions.length === 0) return false;
+    const selectedCount = memberOptions.filter(m =>
+      filters.members?.includes(m.id)
     ).length;
-    return selectedCount > 0 && selectedCount < filtered.length;
+    return selectedCount > 0 && selectedCount < memberOptions.length;
   }
 
   function renderMemberOption(props, option, { selected }) {
@@ -171,9 +172,7 @@ export function FilterMenu() {
                   name="selectAll"
                   checked={
                     memberOptions.length > 0 &&
-                    memberOptions
-                      .filter(m => m.id !== currentUser._id)
-                      .every(m => filters.members?.includes(m.id))
+                    memberOptions.every(m => filters.members?.includes(m.id))
                   }
                   indeterminate={isSomeMembersSelected()}
                   onChange={handleMembersChange}
@@ -190,9 +189,8 @@ export function FilterMenu() {
                 disableClearable
                 options={memberOptions}
                 getOptionLabel={option => option.label}
-                value={memberOptions.filter(
-                  m =>
-                    filters.members?.includes(m.id) && m.id !== currentUser._id
+                value={memberOptions.filter(m =>
+                  filters.members?.includes(m.id)
                 )}
                 onChange={handleMembersAutocompleteChange}
                 renderOption={renderMemberOption}

--- a/frontend/src/services/board/board-service-remote.js
+++ b/frontend/src/services/board/board-service-remote.js
@@ -45,8 +45,31 @@ async function getById(boardId) {
   return data.board;
 }
 
-async function getFullById(boardId) {
-  const data = await httpService.get(`boards/${boardId}/full`);
+async function getFullById(boardId, filterBy = {}) {
+  const params = new URLSearchParams();
+
+  if (filterBy.title) {
+    params.set("title", filterBy.title);
+  }
+  if (filterBy.labels && filterBy.labels.length > 0) {
+    params.set("labels", filterBy.labels.join(","));
+  }
+  if (filterBy.members && filterBy.members.length > 0) {
+    params.set("members", filterBy.members.join(","));
+  }
+  if (filterBy.noMembers) {
+    params.set("noMembers", "1");
+  }
+  if (filterBy.includeNoLabels) {
+    params.set("includeNoLabels", "1");
+  }
+
+  const queryString = params.toString();
+  const url = queryString
+    ? `boards/${boardId}/full?${queryString}`
+    : `boards/${boardId}/full`;
+
+  const data = await httpService.get(url);
   return data.board;
 }
 
@@ -93,7 +116,10 @@ async function updateCardCover(cardId, coverData) {
 }
 
 async function addCardAttachment(cardId, attachment) {
-  const data = await httpService.post(`cards/${cardId}/attachments`, attachment);
+  const data = await httpService.post(
+    `cards/${cardId}/attachments`,
+    attachment
+  );
   return data.card;
 }
 

--- a/frontend/src/services/filter-service.js
+++ b/frontend/src/services/filter-service.js
@@ -61,7 +61,7 @@ export function getDefaultFilter() {
 export function getMembersFilterOptions(members) {
   if (!members) return [];
   return members.map(member => ({
-    id: member._id,
+    id: member.userId,
     label: member.fullname,
     fullname: member.fullname,
     username: member.username,


### PR DESCRIPTION
## 🎯 Description
Implement card filtering in the backend and fix critical issues in the frontend.

## 🔧 Changes
- Imlement a filter service and functionality for filtering card inside `getFullById`
- **🚫 Exclude current user from member list**: Current user is no longer shown in the member autocomplete dropdown since there's already a separate "Assigned to me" checkbox
- **✅ Fix select all checkbox behavior**: The select all checkbox now properly toggles between selecting all available members and clearing the selection, while preserving the "Assigned to me" state when appropriate
- **🎯 Improve checkbox icon states**: Fixed the indeterminate state calculation to correctly show when some (but not all) members are selected
- **🧹 Remove redundant filtering**: Eliminated unnecessary filtering operations for better performance

## 📝 Notes
The changes ensure that:
- Users won't see themselves duplicated in both the member list and "Assigned to me" option
- The select all checkbox provides clear visual feedback (checked/unchecked/indeterminate)
- When using the select all checkbox, it respects the existing "Assigned to me" selection


## 🖥️ Demo

https://github.com/user-attachments/assets/e207a3a6-71d3-4d84-9385-08a5b066fbf7


