### PR TITLE
feature/CATC_153-allow-deleting-cards-and-lists

### DIFF
--- a/backend/src/models/List.js
+++ b/backend/src/models/List.js
@@ -1,4 +1,5 @@
 import mongoose from "mongoose";
+import { Card } from "./Card.js";
 
 const listSchema = new mongoose.Schema(
   {
@@ -38,6 +39,13 @@ listSchema.virtual("cards", {
   ref: "Card",
   localField: "_id",
   foreignField: "listId",
+});
+
+// Cascade delete cards when a list is deleted
+listSchema.pre("findOneAndDelete", async function (next) {
+  const listId = this.getQuery()._id;
+  await Card.deleteMany({ listId });
+  next();
 });
 
 export const List = mongoose.model("List", listSchema);

--- a/frontend/src/components/ListActionsMenu.jsx
+++ b/frontend/src/components/ListActionsMenu.jsx
@@ -12,8 +12,7 @@ import { MoveListForm } from "./MoveListForm";
 import {
   moveList,
   loadBoards,
-  archiveList,
-  archiveAllCardsInList,
+  deleteList,
 } from "../store/actions/board-actions";
 
 export function ListActionsMenu({
@@ -38,10 +37,7 @@ export function ListActionsMenu({
       setActiveAction(null);
       onClose();
     } else if (key === "archiveList") {
-      archiveList(currentBoard._id, list._id);
-      onClose();
-    } else if (key === "archiveAllCards") {
-      archiveAllCardsInList(currentBoard._id, list._id);
+      deleteList(currentBoard._id, list._id);
       onClose();
     } else {
       setActiveAction(key);
@@ -147,6 +143,5 @@ function listActionsMenuItems() {
     { label: "Sort list...", key: "sort" },
     { label: "Watch", key: "watch" },
     { label: "Archive this list", key: "archiveList" },
-    { label: "Archive all cards in this list", key: "archiveAllCards" },
   ];
 }

--- a/frontend/src/services/board/board-service-remote.js
+++ b/frontend/src/services/board/board-service-remote.js
@@ -23,9 +23,8 @@ export const boardService = {
   updateList,
   moveList,
   copyList,
+  deleteList,
   // archiveList,
-  // unarchiveList,
-  // moveAllCards,
   // archiveAllCardsInList,
   updateCardLabels,
   createLabel,
@@ -229,6 +228,11 @@ async function copyList(listId, copyOptions = {}) {
 
   const data = await httpService.post(`lists/${listId}/copy`, mergedOptions);
   return data.list;
+}
+
+async function deleteList(boardId, listId) {
+  const data = await httpService.delete(`lists/${listId}`);
+  return data.id;
 }
 
 // async function archiveList(boardId, listId) {

--- a/frontend/src/store/actions/board-actions.js
+++ b/frontend/src/store/actions/board-actions.js
@@ -8,6 +8,7 @@ import {
   MOVE_LIST,
   UPDATE_LIST,
   COPY_LIST,
+  DELETE_LIST,
   ARCHIVE_LIST,
   UNARCHIVE_LIST,
   ARCHIVE_ALL_CARDS_IN_LIST,
@@ -101,6 +102,12 @@ export const updateList = createAsyncAction(
 export const copyList = createAsyncAction(
   COPY_LIST,
   boardService.copyList,
+  store
+);
+
+export const deleteList = createAsyncAction(
+  DELETE_LIST,
+  boardService.deleteList,
   store
 );
 

--- a/frontend/src/store/reducers/board-reducer.js
+++ b/frontend/src/store/reducers/board-reducer.js
@@ -17,7 +17,9 @@ export const ARCHIVE_ALL_CARDS_IN_LIST = createAsyncActionTypes(
 export const ADD_CARD = createAsyncActionTypes("ADD_CARD");
 export const EDIT_CARD = createAsyncActionTypes("EDIT_CARD");
 export const UPSERT_CARD_COVER = createAsyncActionTypes("UPSERT_CARD_COVER");
-export const ADD_CARD_ATTACHMENT = createAsyncActionTypes("ADD_CARD_ATTACHMENT");
+export const ADD_CARD_ATTACHMENT = createAsyncActionTypes(
+  "ADD_CARD_ATTACHMENT"
+);
 export const REMOVE_CARD_ATTACHMENT = createAsyncActionTypes(
   "REMOVE_CARD_ATTACHMENT"
 );
@@ -29,6 +31,7 @@ export const REMOVE_ASSIGNEE = createAsyncActionTypes("REMOVE_ASSIGNEE");
 export const MOVE_LIST = createAsyncActionTypes("MOVE_LIST");
 export const UPDATE_LIST = createAsyncActionTypes("UPDATE_LIST");
 export const COPY_LIST = createAsyncActionTypes("COPY_LIST");
+export const DELETE_LIST = createAsyncActionTypes("DELETE_LIST");
 export const CREATE_LABEL = createAsyncActionTypes("CREATE_LABEL");
 export const EDIT_LABEL = createAsyncActionTypes("EDIT_LABEL");
 export const DELETE_LABEL = createAsyncActionTypes("DELETE_LABEL");
@@ -157,6 +160,15 @@ const handlers = {
       return state;
     }
   },
+  ...createAsyncHandlers(DELETE_LIST, DELETE_LIST.KEY),
+  [DELETE_LIST.SUCCESS]: (state, action) => ({
+    ...state,
+    loading: { ...state.loading, [DELETE_LIST.KEY]: false },
+    board: {
+      ...state.board,
+      lists: state.board.lists.filter(list => list._id !== action.payload),
+    },
+  }),
   ...createAsyncHandlers(UPDATE_LIST, UPDATE_LIST.KEY),
   [UPDATE_LIST.SUCCESS]: (state, action) => ({
     ...state,
@@ -272,16 +284,12 @@ const handlers = {
     ...state,
     board: {
       ...state.board,
-      lists: state.board.lists.map(list =>
-        list._id === action.payload.listId
-          ? {
-              ...list,
-              cards: list.cards.filter(
-                card => card._id !== action.payload.cardId
-              ),
-            }
-          : list
-      ),
+      lists: state.board.lists.map(list => {
+        return {
+          ...list,
+          cards: list.cards.filter(card => card._id !== action.payload.cardId),
+        };
+      }),
     },
   }),
   ...createAsyncHandlers(COPY_CARD, COPY_CARD.KEY),

--- a/frontend/src/store/reducers/board-reducer.js
+++ b/frontend/src/store/reducers/board-reducer.js
@@ -23,7 +23,7 @@ export const ADD_CARD_ATTACHMENT = createAsyncActionTypes(
 export const REMOVE_CARD_ATTACHMENT = createAsyncActionTypes(
   "REMOVE_CARD_ATTACHMENT"
 );
-export const DELETE_CARD = "DELETE_CARD";
+export const DELETE_CARD = createAsyncActionTypes("DELETE_CARD");
 export const COPY_CARD = createAsyncActionTypes("COPY_CARD");
 export const MOVE_CARD = createAsyncActionTypes("MOVE_CARD");
 export const ADD_ASSIGNEE = createAsyncActionTypes("ADD_ASSIGNEE");
@@ -280,8 +280,10 @@ const handlers = {
     },
   }),
 
-  [DELETE_CARD]: (state, action) => ({
+  ...createAsyncHandlers(DELETE_CARD, DELETE_CARD.KEY),
+  [DELETE_CARD.SUCCESS]: (state, action) => ({
     ...state,
+    loading: { ...state.loading, [DELETE_CARD.KEY]: false },
     board: {
       ...state.board,
       lists: state.board.lists.map(list => {


### PR DESCRIPTION
  ## 🎯 Description
  Implement deletion functionality for cards and lists using existing archive UI components. Archive buttons now
  permanently delete instead of archiving (archival feature postponed).


  ## 🔧 Changes
  - ✅ **List Deletion**: Added `deleteList` service function, action, and reducer
  - ✅ **Cascade Delete**: Mongoose pre-hook automatically deletes cards when list is deleted
  - ✅ **UI Integration**: "Archive this list" button now triggers deletion
  - 🐛 **Fixed DELETE_CARD**: Converted to async action type to fix Redux error

  ## 📝 Notes
  **Backend:**
  - Mongoose `pre('findOneAndDelete')` hook on List model ensures cascade deletion of cards
  - Archive functions remain commented for future implementation

  **Frontend:**
  - DELETE_CARD fixed to use `createAsyncActionTypes` (was plain string causing Redux error)
  - Removed "Archive all cards" option from list actions menu