### PR TITLE
bugfix/CATC_157-editing-card-title-causes-other-elements-to-shift

### DIFF
--- a/frontend/src/assets/styles/components/CardModal.css
+++ b/frontend/src/assets/styles/components/CardModal.css
@@ -186,8 +186,8 @@
   word-wrap: break-word;
   word-break: break-word;
   color: var(--gray1);
-  background-color: var(--gray5, #040a10);
-  border: 1px solid var(--form-input-border-color, #4a9eff);
+  border: none;
+  outline: none;
   border-radius: 4px;
   resize: none;
   overflow: hidden;
@@ -203,9 +203,7 @@
 }
 
 .card-modal-title-input:focus {
-  outline: none;
-  border: none;
-  border-color: var(--form-input-border-color, #4a9eff);
+  outline: 2px solid var(--form-input-border-color, #4a9eff);
 }
 
 .card-modal-title-input::placeholder {

--- a/frontend/src/components/CardModal.jsx
+++ b/frontend/src/components/CardModal.jsx
@@ -109,7 +109,9 @@ export function CardModal({ listTitle, card, onEditCard, onClose, isOpen }) {
                 className="card-modal-title-input"
                 value={cardDetails.title}
                 onChange={e => handleChangeCard("title", e.target.value)}
-                onBlur={() => onEditCard(cardDetails)}
+                onBlur={e =>
+                  e.target.value !== card.title && onEditCard(cardDetails)
+                }
               />
             </div>
             <div className="card-modal-controls">

--- a/frontend/src/components/CardModal.jsx
+++ b/frontend/src/components/CardModal.jsx
@@ -25,7 +25,6 @@ import { useSelector } from "react-redux";
 export function CardModal({ listTitle, card, onEditCard, onClose, isOpen }) {
   const board = useSelector(state => state.boards.board);
   const [openSection, setOpenSection] = useState(false);
-  const [isEditing, setIsEditing] = useState(false);
   const [isEditorOpen, setIsEditorOpen] = useState(false);
   const [cardDetails, setCardDetails] = useState(card);
   const [labelEl, setLabelEl] = useState(null);
@@ -45,12 +44,10 @@ export function CardModal({ listTitle, card, onEditCard, onClose, isOpen }) {
   function handleSaveCard() {
     setIsEditorOpen(false);
     onEditCard(cardDetails);
-    setIsEditing(false);
   }
 
   function handleCancelCard() {
     setIsEditorOpen(false);
-    setIsEditing(false);
     setCardDetails(card);
   }
 
@@ -108,25 +105,12 @@ export function CardModal({ listTitle, card, onEditCard, onClose, isOpen }) {
         <div className="card-modal-container">
           <section className="card-modal-content">
             <div className="card-modal-title-container">
-              {!isEditing ? (
-                <h1
-                  className="card-modal-title"
-                  onClick={() => setIsEditing(true)}
-                >
-                  {cardDetails.title}
-                </h1>
-              ) : (
-                <TextareaAutosize
-                  className="card-modal-title-input"
-                  value={cardDetails.title}
-                  onChange={e => handleChangeCard("title", e.target.value)}
-                  onBlur={() => {
-                    setIsEditing(false);
-                    onEditCard(cardDetails);
-                  }}
-                  autoFocus
-                />
-              )}
+              <TextareaAutosize
+                className="card-modal-title-input"
+                value={cardDetails.title}
+                onChange={e => handleChangeCard("title", e.target.value)}
+                onBlur={() => onEditCard(cardDetails)}
+              />
             </div>
             <div className="card-modal-controls">
               <Button


### PR DESCRIPTION
## 🎯 Description
Fixes UI bug where editing card titles causes other modal elements to shift.

## 🔧 Changes
- **🎨 CSS Update**: Removed borders and background from title input in normal state, making it appear as plain text while maintaining consistent element rendering
- **⚛️ Component Refactor**: Eliminated conditional rendering between `<h1>` and `<TextareaAutosize>` - now always renders textarea to prevent layout shifts without setting fixed heights.
- **🔄 State Simplification**: Removed `isEditing` state management, simplifying the title editing flow

## 📝 Notes
The root cause was switching between different HTML element types (h1 vs textarea) which triggered layout recalculation. By using a single element type and controlling appearance via CSS, the layout remains stable during title editing.
Description was not affected by this PR as other teammates are making modifications that might affect any attempts at fixed it moving modal elements as well.

## 🖥️ Demo

https://github.com/user-attachments/assets/24cc64ac-92df-452c-a7b6-ab0685acbdaf

